### PR TITLE
feat: improve search_events reliability for LLM consumers

### DIFF
--- a/Sources/CheICalMCP/EventKit/EventKitManager.swift
+++ b/Sources/CheICalMCP/EventKit/EventKitManager.swift
@@ -506,9 +506,11 @@ actor EventKitManager {
         try await requestCalendarAccess()
         refreshIfNeeded()
 
-        // Default to a wide date range if not specified
-        let searchStart = startDate ?? Date.distantPast
-        let searchEnd = endDate ?? Date.distantFuture
+        // Default to ±2 years from now. EventKit's predicateForEvents can return
+        // incomplete results with extremely wide ranges (distantPast/distantFuture).
+        let now = Date()
+        let searchStart = startDate ?? Calendar.current.date(byAdding: .year, value: -2, to: now)!
+        let searchEnd = endDate ?? Calendar.current.date(byAdding: .year, value: 2, to: now)!
 
         var calendars: [EKCalendar]?
         if let name = calendarName {
@@ -555,6 +557,49 @@ actor EventKitManager {
             calendarName: calendarName,
             calendarSource: calendarSource
         )
+    }
+
+    /// Find events with similar titles (case-insensitive substring match).
+    /// Used to provide hints when creating events, helping LLMs reuse correct calendar names.
+    /// - Parameters:
+    ///   - title: The title to match against
+    ///   - limit: Maximum number of results (default 5)
+    /// - Returns: Array of matching events, sorted by start date descending (most recent first)
+    func findSimilarEvents(title: String, limit: Int = 5) async throws -> [EKEvent] {
+        try await requestCalendarAccess()
+        refreshIfNeeded()
+
+        let now = Date()
+        let searchStart = Calendar.current.date(byAdding: .year, value: -2, to: now)!
+        let searchEnd = Calendar.current.date(byAdding: .year, value: 2, to: now)!
+
+        let predicate = eventStore.predicateForEvents(withStart: searchStart, end: searchEnd, calendars: nil)
+        let allEvents = eventStore.events(matching: predicate)
+
+        let lowercasedTitle = title.lowercased()
+        // Split title into words for flexible matching
+        let titleWords = lowercasedTitle.split(separator: " ").map(String.init).filter { $0.count >= 2 }
+
+        let matches = allEvents.filter { event in
+            guard let eventTitle = event.title?.lowercased() else { return false }
+            // Match if any significant word from the new title appears in existing event title
+            return titleWords.contains { eventTitle.contains($0) }
+        }
+        .sorted { ($0.startDate ?? .distantPast) > ($1.startDate ?? .distantPast) }
+
+        // Deduplicate by title+calendar (keep most recent)
+        var seen = Set<String>()
+        var unique: [EKEvent] = []
+        for event in matches {
+            let key = "\(event.title ?? "")|\(event.calendar.title)"
+            if !seen.contains(key) {
+                seen.insert(key)
+                unique.append(event)
+            }
+            if unique.count >= limit { break }
+        }
+
+        return unique
     }
 
     // MARK: - Batch Operations

--- a/Sources/CheICalMCP/Server.swift
+++ b/Sources/CheICalMCP/Server.swift
@@ -530,7 +530,7 @@ class CheICalMCPServer {
             // Feature 2: Search Events (enhanced with multi-keyword support)
             Tool(
                 name: "search_events",
-                description: "Search events by keyword(s) in title, notes, or location. Supports single keyword or multiple keywords with AND/OR matching. Without date range, searches all events (may be slow for large calendars).",
+                description: "Search events by keyword(s) in title, notes, or location. Supports single keyword or multiple keywords with AND/OR matching. Without date range, defaults to ±2 years from today. Tip: To find past events beyond 2 years, always specify start_date. The response includes searched_range so you can verify coverage.",
                 inputSchema: .object([
                     "type": .string("object"),
                     "properties": .object([
@@ -588,7 +588,7 @@ class CheICalMCPServer {
             // Feature 4: Batch Create Events
             Tool(
                 name: "create_events_batch",
-                description: "PREFERRED: Create multiple events in a single call. Use this instead of calling create_event multiple times - it's faster and more reliable. Returns detailed results for each event.",
+                description: "PREFERRED: Create multiple events in a single call. Use this instead of calling create_event multiple times - it's faster and more reliable. Returns detailed results for each event. Also returns similar_events hints showing existing events with similar titles, so you can reuse the correct calendar name and avoid duplicates.",
                 inputSchema: .object([
                     "type": .string("object"),
                     "properties": .object([
@@ -1708,16 +1708,21 @@ class CheICalMCPServer {
         }
 
         let matchMode = arguments["match_mode"]?.stringValue ?? "any"
-        let startDate: Date? = try arguments["start_date"]?.stringValue.map { try parseFlexibleDate($0) }
-        let endDate: Date? = try arguments["end_date"]?.stringValue.map { try parseFlexibleDate($0) }
+        let userStartDate: Date? = try arguments["start_date"]?.stringValue.map { try parseFlexibleDate($0) }
+        let userEndDate: Date? = try arguments["end_date"]?.stringValue.map { try parseFlexibleDate($0) }
         let calendarName = arguments["calendar_name"]?.stringValue
         let calendarSource = arguments["calendar_source"]?.stringValue
+
+        // Compute effective search range (same defaults as EventKitManager)
+        let now = Date()
+        let effectiveStart = userStartDate ?? Calendar.current.date(byAdding: .year, value: -2, to: now)!
+        let effectiveEnd = userEndDate ?? Calendar.current.date(byAdding: .year, value: 2, to: now)!
 
         let events = try await eventKitManager.searchEvents(
             keywords: keywords,
             matchMode: matchMode,
-            startDate: startDate,
-            endDate: endDate,
+            startDate: effectiveStart,
+            endDate: effectiveEnd,
             calendarName: calendarName,
             calendarSource: calendarSource
         )
@@ -1757,6 +1762,13 @@ class CheICalMCPServer {
             "keywords": keywords,
             "match_mode": matchMode,
             "result_count": events.count,
+            "searched_range": [
+                "start": dateFormatter.string(from: effectiveStart),
+                "start_local": localDateFormatter.string(from: effectiveStart),
+                "end": dateFormatter.string(from: effectiveEnd),
+                "end_local": localDateFormatter.string(from: effectiveEnd),
+                "is_default_range": userStartDate == nil || userEndDate == nil
+            ] as [String: Any],
             "events": result
         ]
         return formatJSON(response)
@@ -1919,6 +1931,30 @@ class CheICalMCPServer {
         if skippedCount > 0 {
             response["skipped"] = skippedCount
         }
+
+        // Collect unique titles from the batch to find similar existing events
+        let batchTitles = Set(eventsArray.compactMap { $0.objectValue?["title"]?.stringValue })
+        var similarHints: [[String: Any]] = []
+        for title in batchTitles {
+            if let similar = try? await eventKitManager.findSimilarEvents(title: title, limit: 3) {
+                for event in similar {
+                    // Skip events we just created in this batch
+                    let createdIds = Set(results.compactMap { $0["event_id"] as? String })
+                    if let eid = event.eventIdentifier, createdIds.contains(eid) { continue }
+                    similarHints.append([
+                        "matched_title": title,
+                        "existing_title": event.title ?? "",
+                        "existing_calendar": event.calendar.title,
+                        "existing_date": dateFormatter.string(from: event.startDate),
+                        "existing_date_local": localDateFormatter.string(from: event.startDate)
+                    ])
+                }
+            }
+        }
+        if !similarHints.isEmpty {
+            response["similar_events"] = similarHints
+        }
+
         return formatJSON(response)
     }
 


### PR DESCRIPTION
## Summary

Fixes #2 — Improves `search_events` and `create_events_batch` for better LLM interaction reliability.

- **Fix default search range**: Replace `Date.distantPast`/`Date.distantFuture` with ±2 years. EventKit's `predicateForEvents` can silently return incomplete results with extremely wide ranges, causing LLMs to miss past events.
- **Add `searched_range` metadata**: Response now includes `searched_range.start`, `searched_range.end`, and `is_default_range` so LLMs can verify if missing events are truly absent or just outside the searched window.
- **Add LLM tips to tool descriptions**: `search_events` and `create_events_batch` descriptions now include guidance for LLM callers.
- **Add `similar_events` hints**: `create_events_batch` response now returns similar existing events (by title word match) to help LLMs reuse correct calendar names and avoid duplicates.

## Test plan

- [ ] `search_events` without dates: verify response includes `searched_range` with ±2yr range and `is_default_range: true`
- [ ] `search_events` with explicit dates: verify `searched_range` reflects provided dates and `is_default_range: false`
- [ ] `search_events` for a past event within 2 years: verify it's found without specifying dates
- [ ] `create_events_batch`: verify `similar_events` array appears when similar events exist
- [ ] `create_events_batch`: verify no `similar_events` key when no similar events found
- [ ] `swift build` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)