### PR TITLE
cluster: docs (#35 + #38)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ Changes can be parked（暫存）— temporarily moved out of `openspec/changes/
 
 | Filename pattern | Layer | What it tests |
 |------------------|-------|---------------|
-| `<Subject>Tests.swift` | Pure unit | Free functions / value types / pure helpers. No `EventKitManager`, no `FakeEventKitManager`. Examples: `BatchDeleteFilterTests`, `ReminderCleanupTests`, `EventKitErrorSanitizerTests`, `ParticipantFormattingTests`. |
+| `<Subject>Tests.swift` | Pure unit | Free functions / value types / pure helpers. No `FakeEventKitManager` and no `EventKitManager` *instances* (static-utility access like `EventKitManager.isNonInteractive` in `SetupCommandTests` is fine — it's a type-level probe, not handler integration). Examples: `BatchDeleteFilterTests`, `ReminderCleanupTests`, `EventKitErrorSanitizerTests`, `ParticipantFormattingTests`, `SetupCommandTests`. |
 | `<Subject>HandlerTests.swift` | Handler integration | `handle*` methods from `CheICalMCPServer` driven through `FakeEventKitManager`-equivalent doubles. Tests the handler's full sanitize → dispatch → response shape, not the EventKit manager itself. **Canonical example: [`CleanupHandlerTests.swift`](Tests/CheICalMCPTests/CleanupHandlerTests.swift)** — copy its structure when adding a new handler test. |
 | `<Subject>DispatchTests.swift` | Outer-catch / dispatch | `handleToolCallForTesting` outer-catch and the dispatch JSON envelope. Probes what surfaces when a handler throws an unexpected error type. Examples: `OuterCatchDispatchTests`, `DispatchRoundTripTests`. |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,3 +25,17 @@ discuss? → propose → apply ⇄ ingest → archive
 Changes can be parked（暫存）— temporarily moved out of `openspec/changes/`. Parked changes won't appear in `spectra list` but can be found with `spectra list --parked`. To restore: `spectra unpark <name>`. The `/spectra:apply` and `/spectra:ingest` skills handle parked changes automatically.
 
 <!-- SPECTRA:END -->
+
+## Test Naming Convention
+
+`Tests/CheICalMCPTests/` follows three filename suffixes that signal what each test exercises. The suffix is **load-bearing** — pick the right one when adding a new file so reviewers (and Claude) can locate the right test layer fast.
+
+| Filename pattern | Layer | What it tests |
+|------------------|-------|---------------|
+| `<Subject>Tests.swift` | Pure unit | Free functions / value types / pure helpers. No `EventKitManager`, no `FakeEventKitManager`. Examples: `BatchDeleteFilterTests`, `ReminderCleanupTests`, `EventKitErrorSanitizerTests`, `ParticipantFormattingTests`. |
+| `<Subject>HandlerTests.swift` | Handler integration | `handle*` methods from `CheICalMCPServer` driven through `FakeEventKitManager`-equivalent doubles. Tests the handler's full sanitize → dispatch → response shape, not the EventKit manager itself. **Canonical example: [`CleanupHandlerTests.swift`](Tests/CheICalMCPTests/CleanupHandlerTests.swift)** — copy its structure when adding a new handler test. |
+| `<Subject>DispatchTests.swift` | Outer-catch / dispatch | `handleToolCallForTesting` outer-catch and the dispatch JSON envelope. Probes what surfaces when a handler throws an unexpected error type. Examples: `OuterCatchDispatchTests`, `DispatchRoundTripTests`. |
+
+Helper files (e.g., `FakeEventKitManager.swift`) carry no `*Tests` suffix.
+
+When adding a test, ask: am I exercising a pure function (→ `*Tests`), the handler boundary (→ `*HandlerTests`), or the outer dispatch shell (→ `*DispatchTests`)? Mismatched suffix is a `idd-verify` finding worth flagging.

--- a/Sources/CheICalMCP/EventKit/EventKitManager.swift
+++ b/Sources/CheICalMCP/EventKit/EventKitManager.swift
@@ -1823,24 +1823,33 @@ extension EventKitError: TrustedErrorMessage {}
 /// Result of a batch EventKit mutation surfaced to MCP responses.
 ///
 /// `failures[].error` is forwarded verbatim into the wire response; the value
-/// is therefore part of the MCP contract. Three dispatch paths populate it,
-/// each with a different sanitization contract — pick by call site:
+/// is therefore part of the MCP contract. The `failures[].error` string is
+/// produced by **one of three paths** — two are catch-handlers, one is a
+/// raise-without-catch — pick by call site:
 ///
-/// 1. **Pre-catch literals** — author-controlled English strings (e.g.
-///    `"Reminder not found"`, `"Reminder is no longer completed"`) raised
-///    before any `do/catch` block. These are invariants, not error wraps,
-///    and are used as-is.
-/// 2. **`EventKitErrorSanitizer.sanitize(_:)`** — direct binding for the
+/// 1. **Pre-catch raise (no catch needed)** — author-controlled English
+///    strings (e.g. `"Reminder not found"`, `"Reminder is no longer
+///    completed"`) appended directly to `failures` before the catch path
+///    runs. These are guard-style invariants, not error wraps; no sanitizer
+///    is applied because no `Error` was thrown.
+/// 2. **`EventKitErrorSanitizer.sanitize(_:)`** — direct binding inside the
+///    `deleteRemindersBatch` catch (this file only) for the
 ///    `cleanup_completed_reminders` flow per spec R3 (preserves the narrow
-///    `[0-9]+` value-domain). Used in `deleteRemindersBatch` catch only.
+///    `[0-9]+` value-domain).
 /// 3. **`EventKitErrorSanitizer.writeFailureLog(handler:identifier:error:)`**
-///    — R7 helper for the 10 non-cleanup catch sites; combines
-///    `sanitizeForResponse(_:)` + stderr write + return code in one call.
+///    — spec R7 helper used at 10 non-cleanup catch sites across the
+///    project (1 in `EventKitManager.deleteEventsBatch`, 9 in `Server.swift`
+///    handlers). Combines `sanitizeForResponse(_:)` + stderr write + the
+///    response token in one call.
 ///
 /// Catch-block paths that wrap `error.localizedDescription` MUST route
-/// through one of (2) or (3) so Apple-produced text never reaches the client
-/// (see #32, #37). See [`EventKitErrorSanitizer`](EventKitErrorSanitizer.swift)
-/// for the full sanitizer surface.
+/// through (2) or (3) so Apple-produced text never reaches the client
+/// (see #32, #37). Spec R3/R7 numbering originates from the archived change
+/// proposal `2026-04-26-extend-error-sanitizer-dispatch`; current
+/// `openspec/specs/eventkit-error-sanitization/spec.md` carries the
+/// requirements as prose, not as `R<N>` anchors. See
+/// [`EventKitErrorSanitizer`](EventKitErrorSanitizer.swift) for the full
+/// sanitizer surface.
 struct BatchDeleteResult {
     let successCount: Int
     let failedCount: Int

--- a/Sources/CheICalMCP/EventKit/EventKitManager.swift
+++ b/Sources/CheICalMCP/EventKit/EventKitManager.swift
@@ -1823,11 +1823,24 @@ extension EventKitError: TrustedErrorMessage {}
 /// Result of a batch EventKit mutation surfaced to MCP responses.
 ///
 /// `failures[].error` is forwarded verbatim into the wire response; the value
-/// is therefore part of the MCP contract. Pre-catch invariants (e.g.
-/// `"Reminder not found"`) may use literal strings authored in this file.
-/// Catch-block paths that wrap an `error.localizedDescription` MUST route
-/// through `EventKitErrorSanitizer.sanitize(_:)` so Apple-produced text
-/// never reaches the client (see #32).
+/// is therefore part of the MCP contract. Three dispatch paths populate it,
+/// each with a different sanitization contract — pick by call site:
+///
+/// 1. **Pre-catch literals** — author-controlled English strings (e.g.
+///    `"Reminder not found"`, `"Reminder is no longer completed"`) raised
+///    before any `do/catch` block. These are invariants, not error wraps,
+///    and are used as-is.
+/// 2. **`EventKitErrorSanitizer.sanitize(_:)`** — direct binding for the
+///    `cleanup_completed_reminders` flow per spec R3 (preserves the narrow
+///    `[0-9]+` value-domain). Used in `deleteRemindersBatch` catch only.
+/// 3. **`EventKitErrorSanitizer.writeFailureLog(handler:identifier:error:)`**
+///    — R7 helper for the 10 non-cleanup catch sites; combines
+///    `sanitizeForResponse(_:)` + stderr write + return code in one call.
+///
+/// Catch-block paths that wrap `error.localizedDescription` MUST route
+/// through one of (2) or (3) so Apple-produced text never reaches the client
+/// (see #32, #37). See [`EventKitErrorSanitizer`](EventKitErrorSanitizer.swift)
+/// for the full sanitizer surface.
 struct BatchDeleteResult {
     let successCount: Int
     let failedCount: Int


### PR DESCRIPTION
## Cluster

This PR addresses the **docs cluster** (per IDD v2.34.0+ cluster-PR mode):

- Refs #35 — Document test naming convention (`*Tests` / `*HandlerTests` / `*DispatchTests`) in top-level `CLAUDE.md`
- Refs #38 — Enumerate three dispatch paths in `BatchDeleteResult` docstring (pre-catch literals / `sanitize(_:)` / `writeFailureLog`)

Both are pure-docs changes with no behavior impact. They share one feature branch (`idd/cluster-docs`) and one PR because they're thematically tied (both clarify post-#37 sanitizer-dispatch surface and the test layers that probe it). Per-commit `Refs #N` strictly tags the originating issue so audit trail per-issue is preserved.

## Commits

| Commit | Issue | Change |
|--------|-------|--------|
| `a6c676e` | #35 | Add Test naming convention section to `CLAUDE.md` (after `<!-- SPECTRA:END -->` marker so it survives Spectra auto-management) |
| `1d7d562` | #38 | Update `BatchDeleteResult` docstring to enumerate three dispatch paths with spec references (#32, #37) |

## Verification

- [x] Build clean (`swift build` after `make clean` to clear stale cache from earlier Swift toolchain)
- [x] No code/test changes — docstring + project-doc only
- [x] `Tests/CheICalMCPTests/*.swift` inventory confirms the new naming convention fits all 19 existing files as-is — no rename forced

## IDD discipline

- Each commit references exactly one issue (`Refs #35` or `Refs #38`), never both
- **No `Closes` / `Fixes` / `Resolves` trailers** — IDD requires manual `/idd-close` after merge to enforce checklist gate + closing summary

## Checklist

- [x] Diagnose (#35, #38)
- [x] Implement (2 commits)
- [ ] Verify (run `/idd-verify #35 #38` for partitioned cluster verify)
- [ ] **Pending: human review of this PR + per-issue `/idd-close` after merge**

---

Generated by `/idd-implement #35 #38 --pr` on PR path. After merge, run `/issue-driven-dev:idd-close #35 #38` — cluster close will write per-issue closing summaries (no batched fake summary).
