### PR TITLE
cluster: error-sanitizer hardening + DI test seam convention (#39, #40, #41, #34)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,3 +39,20 @@ Changes can be parked（暫存）— temporarily moved out of `openspec/changes/
 Helper files (e.g., `FakeEventKitManager.swift`) carry no `*Tests` suffix.
 
 When adding a test, ask: am I exercising a pure function (→ `*Tests`), the handler boundary (→ `*HandlerTests`), or the outer dispatch shell (→ `*DispatchTests`)? Mismatched suffix is a `idd-verify` finding worth flagging.
+
+## Test Seam Convention (DI for handlers)
+
+`CheICalMCPServer` exposes EventKit primitives via two concurrent paths:
+
+1. **Concrete singleton** — `eventKitManager: EventKitManager` (used by 30+ handlers). Production behavior. Not unit-testable in isolation.
+2. **Per-feature narrow protocol** — e.g. `reminderCleanupSource: any EventKitManaging` (#31), used only by `handleCleanupCompletedReminders`. Default-defaults to `EventKitManager.shared` so production callers don't see the seam; tests inject a fake.
+
+When a handler needs a test fake, **introduce a new narrow `*Source` protocol scoped to that handler's surface area** (1–3 methods is typical). Do NOT widen `EventKitManaging` to cover the new handler's needs — #31 D1 deliberately keeps that protocol tight to avoid forcing every fake to stub unrelated methods.
+
+**Naming**: `<Domain>Source` (e.g. `EventBatchDeletionSource`, `ReminderTagSource`).
+
+**Injection point**: add a constructor parameter with `EventKitManager.shared` as the default. The concrete `eventKitManager` property stays — these coexist.
+
+**Canonical example**: `reminderCleanupSource` in `CheICalMCPServer.init` + `Tests/CheICalMCPTests/CleanupHandlerTests.swift`. New handler tests should mirror that structure.
+
+This convention is **per-handler doc**, not a refactor: existing 30+ handlers continue to use `eventKitManager` directly — no migration debt. The seam appears only when a handler graduates into the test surface.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ When adding a test, ask: am I exercising a pure function (→ `*Tests`), the han
 `CheICalMCPServer` exposes EventKit primitives via two concurrent paths:
 
 1. **Concrete singleton** — `eventKitManager: EventKitManager` (used by 30+ handlers). Production behavior. Not unit-testable in isolation.
-2. **Per-feature narrow protocol** — e.g. `reminderCleanupSource: any EventKitManaging` (#31), used only by `handleCleanupCompletedReminders`. Default-defaults to `EventKitManager.shared` so production callers don't see the seam; tests inject a fake.
+2. **Per-feature narrow protocol** — e.g. `reminderCleanupSource: any EventKitManaging` (#31), used only by `handleCleanupCompletedReminders`. Defaults to `EventKitManager.shared` so production callers don't see the seam; tests inject a fake.
 
 When a handler needs a test fake, **introduce a new narrow `*Source` protocol scoped to that handler's surface area** (1–3 methods is typical). Do NOT widen `EventKitManaging` to cover the new handler's needs — #31 D1 deliberately keeps that protocol tight to avoid forcing every fake to stub unrelated methods.
 

--- a/Sources/CheICalMCP/EventKit/EventKitErrorSanitizer.swift
+++ b/Sources/CheICalMCP/EventKit/EventKitErrorSanitizer.swift
@@ -27,6 +27,18 @@ import Foundation
 /// their messages come from Apple frameworks and may carry user-content.
 /// Checking `is LocalizedError` would be too broad; this empty protocol is
 /// the explicit opt-in used by `eventkit-error-sanitization` spec R5.
+///
+/// **Canonical conformer list** (CheICalMCP module):
+///   - `ToolError` (Server.swift)
+///   - `EventKitError` (EventKit/EventKitManager.swift)
+///   - `CLIRunner.CLIError` (CLIRunner.swift)
+///
+/// Adding a new conformer MUST update both this list AND the test
+/// `testTrustedErrorMessageConformerListIsCanonical` in
+/// `Tests/CheICalMCPTests/EventKitErrorSanitizerTests.swift`. Any
+/// conformance widens the trust boundary, so PR review SHOULD verify
+/// every `errorDescription` of the new type is fully author-controlled
+/// (no string interpolation of user/Apple-framework content).
 public protocol TrustedErrorMessage {}
 
 enum EventKitErrorSanitizer {
@@ -119,18 +131,29 @@ extension EventKitErrorSanitizer {
     /// injection (#37 F2): batch handlers may receive user-supplied
     /// identifiers (event titles, IDs from MCP arguments), and a `\n` in any
     /// of these would forge fake stderr lines visible to the operator.
+    ///
+    /// **Trusted-branch carve-out (#41, spec R7 amendment)**: when `error`
+    /// conforms to `TrustedErrorMessage`, the stderr write is skipped because
+    /// `code == rawLog == localizedDescription` — the wire response already
+    /// carries the same string and stderr would just duplicate. This avoids
+    /// stderr amplification when an attacker sends N malformed batch entries
+    /// (each a `ToolError.invalidParameter`) → N redundant stderr lines.
+    /// Framework errors still write to stderr because they are the only
+    /// operator-debuggable channel for the un-sanitized `localizedDescription`.
     static func writeFailureLog(
         handler: String,
         identifier: String,
         error: Error
     ) -> String {
         let sanitized = sanitizeForResponse(error)
-        let safeHandler = escapeForStderr(handler)
-        let safeIdentifier = escapeForStderr(identifier)
-        let safeRawLog = escapeForStderr(sanitized.rawLog)
-        FileHandle.standardError.write(
-            Data("\(safeHandler)(\(safeIdentifier)) failed: \(safeRawLog)\n".utf8)
-        )
+        if !(error is TrustedErrorMessage) {
+            let safeHandler = escapeForStderr(handler)
+            let safeIdentifier = escapeForStderr(identifier)
+            let safeRawLog = escapeForStderr(sanitized.rawLog)
+            FileHandle.standardError.write(
+                Data("\(safeHandler)(\(safeIdentifier)) failed: \(safeRawLog)\n".utf8)
+            )
+        }
         return sanitized.code
     }
 

--- a/Sources/CheICalMCP/Server.swift
+++ b/Sources/CheICalMCP/Server.swift
@@ -59,6 +59,14 @@ class CheICalMCPServer {
     /// All available tools
     private let tools: [Tool]
 
+    /// Constructor with per-feature test seams.
+    ///
+    /// `reminderCleanupSource` is the canonical example of the "narrow `*Source`
+    /// protocol" DI convention (#34, see `CLAUDE.md` "Test Seam Convention"):
+    /// production code passes nothing → defaults to `EventKitManager.shared`;
+    /// `CleanupHandlerTests` passes a `FakeEventKitManager`. New handlers that
+    /// need a test fake should add their own narrow `*Source` parameter here
+    /// rather than widening `EventKitManaging`.
     init(reminderCleanupSource: any EventKitManaging = EventKitManager.shared) async throws {
         self.reminderCleanupSource = reminderCleanupSource
 

--- a/Sources/CheICalMCP/Server.swift
+++ b/Sources/CheICalMCP/Server.swift
@@ -986,7 +986,21 @@ class CheICalMCPServer {
                 : result
             return CallTool.Result(content: [.text(content)])
         } catch {
+            // Outer catch (#37 spec R8). Per-batch handlers route their own
+            // catches through writeFailureLog; this catch fires only when an
+            // error escapes ALL inner handling — so a framework error here
+            // means the operator's last debug channel is stderr. #39 carve-out:
+            // only write stderr for non-trusted errors. Trusted errors carry
+            // identical text on the wire (`code == rawLog`) so duplicating to
+            // stderr would just amplify noise; framework errors hide their
+            // localizedDescription from the wire (sanitized to a code) so
+            // stderr is the only place to surface it.
             let sanitized = EventKitErrorSanitizer.sanitizeForResponse(error)
+            if !(error is TrustedErrorMessage) {
+                FileHandle.standardError.write(
+                    Data("handleToolCall(\(EventKitErrorSanitizer.escapeForStderr(name))) failed: \(EventKitErrorSanitizer.escapeForStderr(sanitized.rawLog))\n".utf8)
+                )
+            }
             return CallTool.Result(content: [.text("Error: \(sanitized.code)")], isError: true)
         }
     }

--- a/Tests/CheICalMCPTests/EventKitErrorSanitizerTests.swift
+++ b/Tests/CheICalMCPTests/EventKitErrorSanitizerTests.swift
@@ -233,6 +233,30 @@ final class EventKitErrorSanitizerTests: XCTestCase {
         let nsErrCustom: any Error = NSError(domain: "com.example.foo", code: 1)
         XCTAssertFalse(nsErrCustom is TrustedErrorMessage,
                        "raw NSError MUST NOT conform")
+
+        // EKError is the highest-priority gap to pin: its localizedDescription
+        // sources Apple-framework text that may interpolate EKCalendar.title
+        // from CalDAV-shared calendars (#21 / #27 threat class). A maintainer
+        // who adds `extension EKError: TrustedErrorMessage {}` would directly
+        // expose the same surface F1 already had to fix.
+        let ekDomainErr: any Error = NSError(domain: EKErrorDomain, code: 3)
+        XCTAssertFalse(ekDomainErr is TrustedErrorMessage,
+                       "NSError(domain: EKErrorDomain) MUST NOT conform")
+
+        // Codable error types — also LocalizedError-conforming, also
+        // Apple-controlled text (DecodingError context paths can echo JSON
+        // structure including user-supplied field names).
+        let decodeErr: any Error = DecodingError.dataCorrupted(
+            DecodingError.Context(codingPath: [], debugDescription: "x")
+        )
+        XCTAssertFalse(decodeErr is TrustedErrorMessage,
+                       "DecodingError MUST NOT conform — Apple-framework text")
+
+        let encodeErr: any Error = EncodingError.invalidValue(
+            "x", EncodingError.Context(codingPath: [], debugDescription: "x")
+        )
+        XCTAssertFalse(encodeErr is TrustedErrorMessage,
+                       "EncodingError MUST NOT conform — Apple-framework text")
     }
 
     // MARK: - F1 trust contract pin (#37 verify P1 fix)
@@ -324,9 +348,12 @@ final class EventKitErrorSanitizerTests: XCTestCase {
     }
 
     func testWriteFailureLogReturnValueDoesNotEscapeControlChars() {
-        // Control-char escaping applies only to the stderr write — the
-        // returned `code` value is the sanitized response code, untouched.
-        // F2 fix: stderr gets escape; wire response stays as-is.
+        // The returned `code` value is the sanitized response code, untouched.
+        // For TrustedErrorMessage conformers, #41's carve-out skips stderr
+        // entirely — so this test now only exercises the wire-response
+        // identity invariant: trusted error → return value preserves text
+        // verbatim including control chars (which is acceptable on the wire
+        // since MCP `text` content is JSON-encoded, not line-oriented).
         struct WithNewline: LocalizedError, TrustedErrorMessage {
             var errorDescription: String? { "line1\nline2" }
         }
@@ -335,6 +362,6 @@ final class EventKitErrorSanitizerTests: XCTestCase {
             identifier: "i",
             error: WithNewline()
         )
-        XCTAssertEqual(code, "line1\nline2", "wire response value preserves original text; only stderr is escaped")
+        XCTAssertEqual(code, "line1\nline2", "wire response value preserves original text verbatim for trusted errors")
     }
 }

--- a/Tests/CheICalMCPTests/EventKitErrorSanitizerTests.swift
+++ b/Tests/CheICalMCPTests/EventKitErrorSanitizerTests.swift
@@ -192,6 +192,49 @@ final class EventKitErrorSanitizerTests: XCTestCase {
         XCTAssertFalse(err is TrustedErrorMessage)
     }
 
+    func testTrustedErrorMessageConformerListIsCanonical() {
+        // #40: explicit conformer registry. Any new conformance to
+        // TrustedErrorMessage MUST extend the positive list below AND the
+        // canonical list in `TrustedErrorMessage`'s doc comment. The negative
+        // blocklist captures Foundation types whose `localizedDescription`
+        // sources Apple-framework strings — these MUST NOT inherit trust.
+        //
+        // If a maintainer writes `extension URLError: TrustedErrorMessage {}`
+        // to "fix" some unrelated bug, this test fails on the URLError
+        // assertion and the failure message names the offender. "Fixing" the
+        // test would require deleting the negative assertion, which is a
+        // visible diff requiring code-review defense.
+
+        // Positive: known module conformers
+        let toolErr: any Error = ToolError.invalidParameter("x")
+        XCTAssertTrue(toolErr is TrustedErrorMessage, "ToolError must conform")
+
+        let ekErr: any Error = EventKitError.eventNotFound(identifier: "abc")
+        XCTAssertTrue(ekErr is TrustedErrorMessage, "EventKitError must conform")
+
+        let cliErr: any Error = CLIRunner.CLIError.missingToolName
+        XCTAssertTrue(cliErr is TrustedErrorMessage, "CLIRunner.CLIError must conform")
+
+        // Negative: well-known Foundation types must NOT conform — their
+        // localizedDescription sources Apple-framework strings that may
+        // interpolate user-controlled content (#21 / #27 threat class).
+        let urlErr: any Error = URLError(.notConnectedToInternet)
+        XCTAssertFalse(urlErr is TrustedErrorMessage,
+                       "URLError MUST NOT conform — Apple-framework text")
+
+        let posixErr: any Error = POSIXError(.EINVAL)
+        XCTAssertFalse(posixErr is TrustedErrorMessage,
+                       "POSIXError MUST NOT conform — Apple-framework text")
+
+        let cocoaErr: any Error = CocoaError(.fileReadNoSuchFile)
+        XCTAssertFalse(cocoaErr is TrustedErrorMessage,
+                       "CocoaError MUST NOT conform — Apple-framework text")
+
+        let nsErrCustom: any Error = NSError(domain: "com.example.foo", code: 1)
+        XCTAssertFalse(nsErrCustom is TrustedErrorMessage,
+                       "raw NSError MUST NOT conform")
+    }
+
     // MARK: - F1 trust contract pin (#37 verify P1 fix)
 
     func testEventKitErrorCalendarNotFoundDoesNotInterpolateAvailable() {

--- a/openspec/specs/eventkit-error-sanitization/spec.md
+++ b/openspec/specs/eventkit-error-sanitization/spec.md
@@ -169,8 +169,10 @@ The function SHALL NOT mutate global state, perform I/O, or read any field of th
 The system SHALL provide a static function `EventKitErrorSanitizer.writeFailureLog(handler:identifier:error:) -> String`. The function SHALL:
 
 - Compute `let sanitized = sanitizeForResponse(error)`.
-- Write the line `"<handler>(<identifier>) failed: <sanitized.rawLog>\n"` to `FileHandle.standardError`. The literal characters `(` and `)` and `:` SHALL appear as shown.
+- Write the line `"<handler>(<identifier>) failed: <sanitized.rawLog>\n"` to `FileHandle.standardError` if and only if `error` does NOT conform to `TrustedErrorMessage`. The literal characters `(` and `)` and `:` SHALL appear as shown.
 - Return `sanitized.code`.
+
+The trusted-branch carve-out (#41) exists because for `TrustedErrorMessage` conformers, `code == rawLog == localizedDescription` — the wire response already carries the same string and a stderr write would just duplicate. Skipping it prevents stderr amplification when an attacker submits N malformed batch entries (each surfaces a `ToolError.invalidParameter` whose message is already on the response). Framework errors continue to write to stderr because they are the only operator-debuggable channel for the un-sanitized `localizedDescription`.
 
 Callers SHALL use this function in any catch block that previously assigned `error.localizedDescription` directly into an MCP response field, except for the catch block specified in "deleteRemindersBatch catch block routes errors through the sanitizer", which continues to use `sanitize(_:)` directly per its own requirement.
 
@@ -186,6 +188,7 @@ Callers SHALL use this function in any catch block that previously assigned `err
 - **GIVEN** `let err = ToolError.invalidParameter("start_date is required")`
 - **WHEN** `let code = EventKitErrorSanitizer.writeFailureLog(handler: "createEventsBatch", identifier: "0", error: err)` is called
 - **THEN** the returned `code` equals `"Invalid parameter: start_date is required"`
+- **AND** stderr does NOT contain the substring `"createEventsBatch(0) failed:"` (trusted-branch carve-out, #41)
 
 ---
 ### Requirement: Outer handleToolCall catch routes through sanitizeForResponse


### PR DESCRIPTION
## Summary

Cluster-PR closing the 4 long-diagnosed issues from the #44 follow-up triage. Total +115 / −7 across 5 files. Two coherent commits:

1. `feat(error-sanitizer)` — trusted-branch carve-out for stderr writes (#39 + #40 + #41)
2. `docs(di)` — formalize per-handler test seam convention (#34)

## What changes

### #41 — writeFailureLog stderr amplification fix
`EventKitErrorSanitizer.writeFailureLog` now skips the stderr write when `error is TrustedErrorMessage`. Trusted errors carry `code == rawLog == localizedDescription` — the wire response already has the same string, so duplicating to stderr was just noise (and an attacker DOS vector: 10k malformed batch entries → 10k stderr lines on top of the 10k response payloads). Spec R7 gains a carve-out clause + a "stderr does NOT contain" assertion in the trusted scenario.

### #39 — outer catch operator visibility
The outer `handleToolCall` catch (Server.swift:988) gains the symmetric pattern: stderr write for **framework errors only**. Previously an Apple `NSError` reaching the outer catch produced a sanitized code on the wire but never surfaced `rawLog` anywhere — operator was completely blind. Now framework errors surface to stderr (their only debugging channel after sanitization); trusted errors skip stderr (response already carries the text).

### #40 — TrustedErrorMessage conformer guard
New test `testTrustedErrorMessageConformerListIsCanonical` pins the canonical conformer set:

| Positives (must conform) | Negatives (must NOT conform) |
|--------------------------|-------------------------------|
| `ToolError` | raw `NSError` |
| `EventKitError` | `URLError` |
| `CLIRunner.CLIError` | `POSIXError` |
|  | `CocoaError` |

`TrustedErrorMessage` doc comment now lists conformers explicitly with a maintainer contract: "adding a new conformer MUST update both this list AND the test". Sneaking a conformance still requires modifying `TrustedErrorMessage` source; PR review catches it via the visible diff in the doc comment list.

### #34 — DI test seam naming convention
`CLAUDE.md` gains a "Test Seam Convention" section (sibling to the existing "Test Naming Convention"). Future handlers needing a test fake should introduce a narrow `<Domain>Source` protocol (1-3 methods) rather than widening `EventKitManaging`. The concrete `eventKitManager` singleton stays for the existing 30+ handlers — no migration debt; seam appears only when a handler graduates to the test surface.

`CheICalMCPServer.init` gains a doc comment naming `reminderCleanupSource` as the canonical example.

## Trade-offs

- **Stderr capture in tests skipped** per #39/#41 diagnosis recommendation — Swift unit-test stderr capture is fragile (subprocess + dup2 hacks). Contract pinned via doc comment + spec scenario assertion ("AND stderr does NOT contain ...") + manual code review. Production behavior is straightforward `if !(error is TrustedErrorMessage)` guard.
- **TrustedErrorMessage enumeration** — Swift has no clean protocol-conformer enumeration API. The test uses an explicit positive+negative hardcoded list. Less defense-in-depth than runtime introspection, but Swift's `_typeByName` is private API and brittle across Swift versions per the diagnosis. The hardcoded list + protocol doc-comment list is the practical guard.

## Verification

- `swift build`: clean (one pre-existing `unused 'title'` warning at line 1578 — fixed in PR #63's polish bundle, not relevant to this branch)
- `swift test`: **208 tests pass** (207 → 208, +1 new `testTrustedErrorMessageConformerListIsCanonical`)
- Spec R7 still satisfied by existing scenarios + new scenario
- No file conflicts with PRs #63 (polish bundle) or #64 (zh-TW translation) — distinct file sets

## Test plan (post-merge)

- [ ] Manual smoke: trigger a tool call with an unknown name → verify stderr is silent (trusted ToolError path), wire shows "Error: Unknown tool: ..."
- [ ] Manual smoke: cause an Apple `NSError` to escape via `cleanup_completed_reminders` → verify stderr surfaces `handleToolCall(cleanup_completed_reminders) failed: <Apple text>` AND wire shows sanitized `Error: eventkit_error_N`

Closes #34
Closes #39
Closes #40
Closes #41