### PR TITLE
chore: add CODEOWNERS for signing-critical artifact paths (#56)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,24 @@
+# CODEOWNERS — signing-critical artifact map
+#
+# This file documents which paths affect the binary trust chain
+# (codesign identity, notarization flow, entitlements, bundle identity,
+# version consistency checks). Any PR touching these paths should be
+# treated as a supply-chain change regardless of how minor the diff looks.
+#
+# Single-maintainer repo: @kiki830621 entries do not generate self-review
+# requests (GitHub suppresses them on the maintainer's own PRs). Purpose:
+#   1. Explicit documentation of the signing surface.
+#   2. Auto-request readiness if a second contributor gains write access.
+#   3. Branch protection opt-in — enabling "Require review from Code Owners"
+#      under Settings > Branches activates these gates immediately.
+#
+# Intentional exclusion: Sources/CheICalMCP/Version.swift is the embedded
+# version string, not part of the trust chain. Add here only if the version
+# parsing logic itself becomes signing-relevant.
+
+/scripts/sign-and-notarize.sh          @kiki830621
+/scripts/build-mcpb.sh                 @kiki830621
+/Makefile                              @kiki830621
+/Sources/CheICalMCP/Entitlements.plist @kiki830621
+/Sources/CheICalMCP/Info.plist         @kiki830621
+/mcpb/manifest.json                    @kiki830621

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,23 +2,39 @@
 #
 # This file documents which paths affect the binary trust chain
 # (codesign identity, notarization flow, entitlements, bundle identity,
-# version consistency checks). Any PR touching these paths should be
-# treated as a supply-chain change regardless of how minor the diff looks.
+# linker flags, swift-sdk dependency, packaged metadata). Any PR touching
+# these paths should be treated as a supply-chain change regardless of how
+# minor the diff looks.
 #
-# Single-maintainer repo: @kiki830621 entries do not generate self-review
-# requests (GitHub suppresses them on the maintainer's own PRs). Purpose:
-#   1. Explicit documentation of the signing surface.
-#   2. Auto-request readiness if a second contributor gains write access.
-#   3. Branch protection opt-in — enabling "Require review from Code Owners"
-#      under Settings > Branches activates these gates immediately.
+# Owners: @kiki830621 + @Hardy1Yang. Both have admin push access on PsychQuant
+# org and are auto-requested as reviewers when a signing-critical PR is opened
+# by anyone else. PRs authored by an owner do not generate a self-review request
+# (GitHub suppresses self-review), so a co-owner is what makes the auto-request
+# meaningfully fire on the author's own PRs.
 #
-# Intentional exclusion: Sources/CheICalMCP/Version.swift is the embedded
-# version string, not part of the trust chain. Add here only if the version
-# parsing logic itself becomes signing-relevant.
+# Purpose:
+#   1. Explicit documentation of the signing surface (doc-as-code).
+#   2. Auto-request readiness — review request fires the moment a non-owner
+#      (future contributor / bot with write access) opens a signing-critical PR.
+#   3. Branch-protection opt-in — enabling "Require review from Code Owners"
+#      under Settings > Branches turns the auto-request into an enforcement
+#      gate. Note: this also requires base "Require pull request reviews" to be
+#      enabled for the requirement to bind on merges.
+#
+# Self-protection: this file owns itself, so a PR removing or relaxing the
+# coverage list is itself flagged for code-owner review.
+#
+# Intentional exclusion: Sources/CheICalMCP/Version.swift is version-only
+# metadata, not codesign-trust-chain input. The build-mcpb.sh Step 0.5
+# consistency check between Version.swift / Info.plist / mcpb/manifest.json
+# already catches drift on the canonical release path, and Version.swift
+# changes on every release — including it would dilute the security signal.
 
-/scripts/sign-and-notarize.sh          @kiki830621
-/scripts/build-mcpb.sh                 @kiki830621
-/Makefile                              @kiki830621
-/Sources/CheICalMCP/Entitlements.plist @kiki830621
-/Sources/CheICalMCP/Info.plist         @kiki830621
-/mcpb/manifest.json                    @kiki830621
+/scripts/sign-and-notarize.sh          @kiki830621 @Hardy1Yang
+/scripts/build-mcpb.sh                 @kiki830621 @Hardy1Yang
+/Makefile                              @kiki830621 @Hardy1Yang
+/Sources/CheICalMCP/Entitlements.plist @kiki830621 @Hardy1Yang
+/Sources/CheICalMCP/Info.plist         @kiki830621 @Hardy1Yang
+/mcpb/manifest.json                    @kiki830621 @Hardy1Yang
+/Package.swift                         @kiki830621 @Hardy1Yang
+/.github/CODEOWNERS                    @kiki830621 @Hardy1Yang


### PR DESCRIPTION
Refs #56

## Summary

Single new file `.github/CODEOWNERS` with 6 per-path entries scoped to signing-critical artifacts (codesign + notarization scripts, Makefile, entitlements, Info.plist bundle identity, `mcpb/manifest.json`).

## What this PR does

Documents the binary trust chain explicitly so AI reviewers, security audits, and any future contributors see the blast-radius map immediately. Single-maintainer repo: `@kiki830621` entries do not auto-request review on the maintainer's own PRs (GitHub suppresses self-review). The file's value is:

1. **Documentation-as-code** — explicit signing-surface map
2. **Auto-request readiness** — fires the moment a second contributor or bot gains write access
3. **Branch protection opt-in** — enabling "Require review from Code Owners" under Settings > Branches activates these gates immediately

## Decisions per plan

- **D1** Owner = `@kiki830621` despite self-review suppression. Documentation + future-proofing value.
- **D2** Per-path entries (6 paths), NOT a `* @kiki830621` blanket — blanket would dilute the security signal.
- **D3** No bot/AI co-reviewers — GitHub requires write access; AI review happens via CI / `/idd-verify`.

## Out of scope (deferred)

- `/.github/workflows/release.yml @kiki830621` — added in same PR as #51 (CI/CD bootstrap), not pre-emptively here.
- Branch protection rules on `main` — separate manual settings change; tracked under #51.
- Entries for non-signing files — would dilute the signal.

## Checklist

- [x] Diagnose (Implementation Plan posted at https://github.com/PsychQuant/che-ical-mcp/issues/56#issuecomment-4376473541)
- [x] Implement (1 commit, 1 file, +24 lines)
- [ ] Verify (run `/idd-verify --pr <N>`)
- [ ] **Pending: human review of this PR + `/idd-close #56` after merge**

---
Generated by `/idd-implement` on PR path. **Do NOT add `Closes #56`** — IDD discipline requires manual `/idd-close` after merge to enforce checklist gate + closing summary.
