### PR TITLE
cluster: Wave 3 simple verify-followups (#67, #69, #71, #72, #77)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ openspec/.vector-search.db*
 .claude/settings.local.json
 .claude/issue-driven-dev.local.md
 .claude/scheduled_tasks.lock
+.claude/worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,10 +49,10 @@ When adding a test, ask: am I exercising a pure function (→ `*Tests`), the han
 
 When a handler needs a test fake, **introduce a new narrow `*Source` protocol scoped to that handler's surface area** (1–3 methods is typical). Do NOT widen `EventKitManaging` to cover the new handler's needs — #31 D1 deliberately keeps that protocol tight to avoid forcing every fake to stub unrelated methods.
 
-**Naming**: `<Domain>Source` (e.g. `EventBatchDeletionSource`, `ReminderTagSource`).
+**Naming**: `<Domain>Source` (e.g. `EventBatchDeletionSource`, `ReminderTagSource`). The naming guidance applies to **new** protocols going forward; the existing `EventKitManaging` (#31, scoped narrow per its origin) keeps its name for compatibility — the protocol-typed parameter name (`reminderCleanupSource`) need not match the protocol's name (`EventKitManaging`). When introducing a new test seam, name the new protocol per `<Domain>Source` rather than reusing `EventKitManaging`.
 
 **Injection point**: add a constructor parameter with `EventKitManager.shared` as the default. The concrete `eventKitManager` property stays — these coexist.
 
-**Canonical example**: `reminderCleanupSource` in `CheICalMCPServer.init` + `Tests/CheICalMCPTests/CleanupHandlerTests.swift`. New handler tests should mirror that structure.
+**Canonical example**: `reminderCleanupSource` in `CheICalMCPServer.init` + `Tests/CheICalMCPTests/CleanupHandlerTests.swift`. New handler tests should mirror that structure (the *injection pattern* — narrow protocol, default to shared singleton, inject in tests). The protocol *name* `EventKitManaging` is grandfathered; new protocols should use `<Domain>Source`.
 
 This convention is **per-handler doc**, not a refactor: existing 30+ handlers continue to use `eventKitManager` directly — no migration debt. The seam appears only when a handler graduates into the test surface.

--- a/Sources/CheICalMCP/EventKit/EventKitManager.swift
+++ b/Sources/CheICalMCP/EventKit/EventKitManager.swift
@@ -1407,15 +1407,17 @@ actor EventKitManager: EventKitManaging {
                 // we share `escapeForStderr` to keep both paths consistent
                 // without violating R3.
                 //
-                // #69: mirror R7's trusted-branch carve-out — skip the stderr
-                // write when `error` conforms to `TrustedErrorMessage`. The
-                // wire response already carries `code == rawLog == localized
-                // description` for trusted errors, so duplicating to stderr
-                // would just amplify noise (DoS surface for an attacker who
-                // submits N malformed identifiers). Framework errors still
-                // write to stderr because their `localizedDescription` is
-                // sanitized off the wire and stderr is the only operator-
-                // debuggable channel.
+                // #69: defensive symmetry with R7's trusted-branch carve-out
+                // at writeFailureLog. Note the rationale differs here: R3
+                // binds to `sanitize(_:)` directly (NOT `sanitizeForResponse`)
+                // so trusted errors at this site receive a framework-style
+                // code (e.g. "error_unknown") that does NOT equal `rawLog`.
+                // The gate is therefore forward-compat hardening — if a
+                // future caller of `deleteRemindersBatch` propagates a
+                // `TrustedErrorMessage` conformer through this path, the
+                // stderr-amplification window stays closed by construction.
+                // In practice today, `eventStore.remove(reminder:commit:)`
+                // only throws NSError, so the gate doesn't fire on hot paths.
                 let sanitized = EventKitErrorSanitizer.sanitize(error)
                 if !(error is TrustedErrorMessage) {
                     let safeId = EventKitErrorSanitizer.escapeForStderr(id)

--- a/Sources/CheICalMCP/EventKit/EventKitManager.swift
+++ b/Sources/CheICalMCP/EventKit/EventKitManager.swift
@@ -1406,12 +1406,24 @@ actor EventKitManager: EventKitManaging {
                 // missing the control-char escape applied by `writeFailureLog`;
                 // we share `escapeForStderr` to keep both paths consistent
                 // without violating R3.
+                //
+                // #69: mirror R7's trusted-branch carve-out — skip the stderr
+                // write when `error` conforms to `TrustedErrorMessage`. The
+                // wire response already carries `code == rawLog == localized
+                // description` for trusted errors, so duplicating to stderr
+                // would just amplify noise (DoS surface for an attacker who
+                // submits N malformed identifiers). Framework errors still
+                // write to stderr because their `localizedDescription` is
+                // sanitized off the wire and stderr is the only operator-
+                // debuggable channel.
                 let sanitized = EventKitErrorSanitizer.sanitize(error)
-                let safeId = EventKitErrorSanitizer.escapeForStderr(id)
-                let safeRawLog = EventKitErrorSanitizer.escapeForStderr(sanitized.rawLog)
-                FileHandle.standardError.write(
-                    Data("deleteRemindersBatch(\(safeId)) failed: \(safeRawLog)\n".utf8)
-                )
+                if !(error is TrustedErrorMessage) {
+                    let safeId = EventKitErrorSanitizer.escapeForStderr(id)
+                    let safeRawLog = EventKitErrorSanitizer.escapeForStderr(sanitized.rawLog)
+                    FileHandle.standardError.write(
+                        Data("deleteRemindersBatch(\(safeId)) failed: \(safeRawLog)\n".utf8)
+                    )
+                }
                 failures.append((id, sanitized.code))
             }
         }

--- a/Sources/CheICalMCP/Server.swift
+++ b/Sources/CheICalMCP/Server.swift
@@ -997,19 +997,17 @@ class CheICalMCPServer {
             // Outer catch (#37 spec R8). Per-batch handlers route their own
             // catches through writeFailureLog; this catch fires only when an
             // error escapes ALL inner handling — so a framework error here
-            // means the operator's last debug channel is stderr. #39 carve-out:
-            // only write stderr for non-trusted errors. Trusted errors carry
-            // identical text on the wire (`code == rawLog`) so duplicating to
-            // stderr would just amplify noise; framework errors hide their
-            // localizedDescription from the wire (sanitized to a code) so
-            // stderr is the only place to surface it.
-            let sanitized = EventKitErrorSanitizer.sanitizeForResponse(error)
-            if !(error is TrustedErrorMessage) {
-                FileHandle.standardError.write(
-                    Data("handleToolCall(\(EventKitErrorSanitizer.escapeForStderr(name))) failed: \(EventKitErrorSanitizer.escapeForStderr(sanitized.rawLog))\n".utf8)
-                )
-            }
-            return CallTool.Result(content: [.text("Error: \(sanitized.code)")], isError: true)
+            // means the operator's last debug channel is stderr. Delegates to
+            // `writeFailureLog` (#72) so the #41 / R7 trusted-branch carve-out,
+            // `escapeForStderr`, and any future hardening (#73 ANSI/NUL,
+            // thread-safety) are inherited from a single site instead of
+            // duplicated here.
+            let code = EventKitErrorSanitizer.writeFailureLog(
+                handler: "handleToolCall",
+                identifier: name,
+                error: error
+            )
+            return CallTool.Result(content: [.text("Error: \(code)")], isError: true)
         }
     }
 

--- a/openspec/specs/eventkit-error-sanitization/spec.md
+++ b/openspec/specs/eventkit-error-sanitization/spec.md
@@ -64,7 +64,7 @@ The `rawLog` value is intended only for stderr logging on the server process and
 
 `EventKitManager.deleteRemindersBatch(identifiers:onlyCompleted:)` SHALL, in its `catch` block that handles `eventStore.remove(reminder:commit:)` failures, invoke `EventKitErrorSanitizer.sanitize(_:)` on the caught error. The method SHALL append the returned `code` as the second element of the `failures` tuple, and SHALL NOT append `error.localizedDescription` or any substring derived from it.
 
-The method SHALL write the returned `rawLog` value to `FileHandle.standardError` in a single line of the form `"deleteRemindersBatch(<identifier>) failed: <rawLog>\n"` before appending to `failures`, **if and only if** `error` does NOT conform to `TrustedErrorMessage`. (Mirrors the writeFailureLog carve-out — same rationale: trusted errors carry `code == rawLog` on the wire, so duplicating to stderr would just amplify noise; framework errors hide their `localizedDescription` from the wire and need stderr as the only operator-debuggable channel.)
+The method SHALL write the returned `rawLog` value to `FileHandle.standardError` in a single line of the form `"deleteRemindersBatch(<identifier>) failed: <rawLog>\n"` before appending to `failures`, **if and only if** `error` does NOT conform to `TrustedErrorMessage`. (Defensive symmetry with the writeFailureLog carve-out at R7. Note the rationale differs slightly here: R3 binds to `sanitize(_:)` directly — not `sanitizeForResponse(_:)` — so trusted errors at this site receive a framework-style code (e.g. `"error_unknown"`) that does NOT equal `rawLog`. The carve-out is therefore not "the wire response already carries the same string" — instead, it's a forward-compat hardening: if a future caller of `deleteRemindersBatch` propagates a `TrustedErrorMessage` conformer through this path, the stderr-amplification window stays closed by construction. In practice today, `eventStore.remove(reminder:commit:)` only throws `NSError`, so the gate doesn't fire on hot paths.)
 
 Pre-catch failure strings (`"Reminder not found"`, `"Reminder is no longer completed"`) are not affected by this requirement and SHALL continue to be appended literally.
 
@@ -199,7 +199,7 @@ Callers SHALL use this function in any catch block that previously assigned `err
 - **AND** stderr does NOT contain the substring `"createEventsBatch(0) failed:"` (trusted-branch carve-out, #41)
 
 ---
-### Requirement: Outer handleToolCall catch routes through sanitizeForResponse
+### Requirement: Outer handleToolCall catch delegates to writeFailureLog
 
 The outer `catch` block of `CheICalMCPServer.handleToolCall` (located at `Sources/CheICalMCP/Server.swift` line 989 at the time of this requirement) SHALL produce its `CallTool.Result` by delegating to `EventKitErrorSanitizer.writeFailureLog(handler: "handleToolCall", identifier: name, error: error)` and returning `CallTool.Result(content: [.text("Error: \(returnedCode)")], isError: true)` where `returnedCode` is the function's return value.
 

--- a/openspec/specs/eventkit-error-sanitization/spec.md
+++ b/openspec/specs/eventkit-error-sanitization/spec.md
@@ -64,7 +64,7 @@ The `rawLog` value is intended only for stderr logging on the server process and
 
 `EventKitManager.deleteRemindersBatch(identifiers:onlyCompleted:)` SHALL, in its `catch` block that handles `eventStore.remove(reminder:commit:)` failures, invoke `EventKitErrorSanitizer.sanitize(_:)` on the caught error. The method SHALL append the returned `code` as the second element of the `failures` tuple, and SHALL NOT append `error.localizedDescription` or any substring derived from it.
 
-The method SHALL write the returned `rawLog` value to `FileHandle.standardError` in a single line of the form `"deleteRemindersBatch(<identifier>) failed: <rawLog>\n"` before appending to `failures`.
+The method SHALL write the returned `rawLog` value to `FileHandle.standardError` in a single line of the form `"deleteRemindersBatch(<identifier>) failed: <rawLog>\n"` before appending to `failures`, **if and only if** `error` does NOT conform to `TrustedErrorMessage`. (Mirrors the writeFailureLog carve-out — same rationale: trusted errors carry `code == rawLog` on the wire, so duplicating to stderr would just amplify noise; framework errors hide their `localizedDescription` from the wire and need stderr as the only operator-debuggable channel.)
 
 Pre-catch failure strings (`"Reminder not found"`, `"Reminder is no longer completed"`) are not affected by this requirement and SHALL continue to be appended literally.
 
@@ -73,6 +73,14 @@ Pre-catch failure strings (`"Reminder not found"`, `"Reminder is no longer compl
 - **GIVEN** `deleteRemindersBatch(identifiers: ["r1"], onlyCompleted: false)` where `eventStore.remove` throws `NSError(domain: EKErrorDomain, code: 3)`
 - **WHEN** the method returns
 - **THEN** the returned `BatchDeleteResult.failures` contains exactly one entry `(identifier: "r1", error: "eventkit_error_3")`
+- **AND** stderr contains the substring `"deleteRemindersBatch(r1) failed:"`
+
+#### Scenario: Trusted error in deleteRemindersBatch skips stderr
+
+- **GIVEN** `deleteRemindersBatch(identifiers: ["r1"], onlyCompleted: false)` where the catch block receives a `TrustedErrorMessage` conformer (e.g. `ToolError.invalidParameter("bogus id")`)
+- **WHEN** the method returns
+- **THEN** the returned `BatchDeleteResult.failures` contains an entry whose error equals the sanitized code
+- **AND** stderr does NOT contain the substring `"deleteRemindersBatch(r1) failed:"`
 
 #### Scenario: Pre-catch invariants still use literal strings
 
@@ -193,12 +201,14 @@ Callers SHALL use this function in any catch block that previously assigned `err
 ---
 ### Requirement: Outer handleToolCall catch routes through sanitizeForResponse
 
-The outer `catch` block of `CheICalMCPServer.handleToolCall` (located at `Sources/CheICalMCP/Server.swift` line 989 at the time of this requirement) SHALL produce its `CallTool.Result` by:
+The outer `catch` block of `CheICalMCPServer.handleToolCall` (located at `Sources/CheICalMCP/Server.swift` line 989 at the time of this requirement) SHALL produce its `CallTool.Result` by delegating to `EventKitErrorSanitizer.writeFailureLog(handler: "handleToolCall", identifier: name, error: error)` and returning `CallTool.Result(content: [.text("Error: \(returnedCode)")], isError: true)` where `returnedCode` is the function's return value.
 
-- Calling `EventKitErrorSanitizer.sanitizeForResponse(error)` on the caught error.
-- Returning `CallTool.Result(content: [.text("Error: \(sanitized.code)")], isError: true)`.
+By construction (per the `writeFailureLog` requirement below), this delegation:
 
-The block SHALL NOT pass `error.localizedDescription` (or any substring derived from it) directly into the returned `text` content, except via the trusted-pass-through branch of `sanitizeForResponse`.
+- Sanitizes the error via `sanitizeForResponse(error)` for the wire `code`.
+- Writes the line `"handleToolCall(<name>) failed: <sanitized.rawLog>\n"` to `FileHandle.standardError` **if and only if** `error` does NOT conform to `TrustedErrorMessage`. (Mirrors the R3 / R7 carve-outs — same rationale: trusted errors carry `code == rawLog` on the wire; framework errors hide their `localizedDescription` from the wire and need stderr as the only operator-debuggable channel.)
+
+The block SHALL NOT pass `error.localizedDescription` (or any substring derived from it) directly into the returned `text` content, except via the trusted-pass-through branch of `sanitizeForResponse` (which `writeFailureLog` invokes internally).
 
 The wire shape `"Error: <text>"` SHALL remain unchanged from prior behavior to avoid a breaking change for MCP clients that display the text verbatim.
 
@@ -215,6 +225,14 @@ The wire shape `"Error: <text>"` SHALL remain unchanged from prior behavior to a
 - **WHEN** the outer catch block runs
 - **THEN** the returned `CallTool.Result.content` contains exactly one `.text` element with content `"Error: eventkit_error_3"`
 - **AND** `CallTool.Result.isError` equals `true`
+- **AND** stderr contains the substring `"handleToolCall(<name>) failed:"`
+
+#### Scenario: Trusted error at outer catch skips stderr
+
+- **GIVEN** an MCP tool invocation `bogus` that causes `handleToolCall` to throw `ToolError.unknownTool("bogus")`
+- **WHEN** the outer catch block runs
+- **THEN** the returned `CallTool.Result.content[0].text` equals `"Error: Unknown tool: bogus"`
+- **AND** stderr does NOT contain the substring `"handleToolCall(bogus) failed:"`
 
 ---
 ### Requirement: Affected non-cleanup catch blocks dispatch via writeFailureLog

--- a/scripts/sign-and-notarize.sh
+++ b/scripts/sign-and-notarize.sh
@@ -174,7 +174,36 @@ fi
 # choice rationale.
 echo ""
 echo "[4/5] Cross-checking notarization with spctl..."
-SPCTL_OUTPUT="$(spctl -a -vvv -t install "$BINARY" 2>&1)" || true
+# spctl makes a network call to Apple's OCSP servers (ocsp.apple.com,
+# valid.apple.com) to verify the notarization stamp. If OCSP is slow or
+# unreachable (corporate proxy filter, captive portal, transient outage),
+# spctl can hang indefinitely without surfacing a useful error. Wrap in a
+# timeout so a stalled call exits with a clear diagnostic instead of
+# silently stalling `make release-signed`. (#77 hardening)
+#
+# perl alarm is portable on macOS (perl is always present); GNU `timeout`
+# requires `brew install coreutils` and isn't guaranteed in CI environments.
+# Override via SPCTL_TIMEOUT_SECONDS env var if 60s is too short for slow
+# corporate links.
+SPCTL_TIMEOUT_SECONDS="${SPCTL_TIMEOUT_SECONDS:-60}"
+SPCTL_EXIT=0
+SPCTL_OUTPUT="$(perl -e 'alarm shift; exec @ARGV' "$SPCTL_TIMEOUT_SECONDS" \
+    spctl -a -vvv -t install "$BINARY" 2>&1)" || SPCTL_EXIT=$?
+if [ "$SPCTL_EXIT" -eq 142 ]; then
+    # perl alarm exit code: 128 + SIGALRM (14) = 142
+    echo "Error: spctl timed out after ${SPCTL_TIMEOUT_SECONDS}s." >&2
+    echo "       Apple's OCSP infrastructure (ocsp.apple.com, valid.apple.com)" >&2
+    echo "       is likely unreachable or slow." >&2
+    echo "       Possible causes:" >&2
+    echo "         - Corporate VPN / proxy filtering OCSP endpoints" >&2
+    echo "         - Captive portal not yet authenticated" >&2
+    echo "         - Apple OCSP transient outage" >&2
+    echo "         - DNS resolution stalling" >&2
+    echo "" >&2
+    echo "       Workaround: set SPCTL_TIMEOUT_SECONDS=N for slower links," >&2
+    echo "       or re-run after network connectivity is restored." >&2
+    exit 1
+fi
 if ! echo "$SPCTL_OUTPUT" | grep -q "source=Notarized Developer ID"; then
     echo "Error: spctl does not recognize $BINARY as notarized." >&2
     echo "       This is a partial-state failure: codesign succeeded + notarytool" >&2

--- a/scripts/sign-and-notarize.sh
+++ b/scripts/sign-and-notarize.sh
@@ -186,9 +186,22 @@ echo "[4/5] Cross-checking notarization with spctl..."
 # Override via SPCTL_TIMEOUT_SECONDS env var if 60s is too short for slow
 # corporate links.
 SPCTL_TIMEOUT_SECONDS="${SPCTL_TIMEOUT_SECONDS:-60}"
+# Validate as positive integer — guards against silently disabled timeouts
+# (alarm 0 = no alarm; non-numeric → 0; negative → perl interprets as flag
+# without `--` separator). Surface a clear error rather than letting the
+# script regress to pre-#77 hang behavior.
+if ! [[ "$SPCTL_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]]; then
+    echo "Error: SPCTL_TIMEOUT_SECONDS must be a positive integer (got '$SPCTL_TIMEOUT_SECONDS')." >&2
+    echo "       0 / negative / non-integer values would silently disable the timeout" >&2
+    echo "       and re-introduce the indefinite-hang behavior #77 fixed." >&2
+    exit 1
+fi
 SPCTL_EXIT=0
-SPCTL_OUTPUT="$(perl -e 'alarm shift; exec @ARGV' "$SPCTL_TIMEOUT_SECONDS" \
-    spctl -a -vvv -t install "$BINARY" 2>&1)" || SPCTL_EXIT=$?
+# Use `--` separator before timeout value so a bash-passed negative or
+# leading-dash value cannot be interpreted as a perl flag (defense-in-depth
+# even though the regex above already rejects non-positive-integer values).
+SPCTL_OUTPUT="$(perl -e 'my $t=shift; alarm $t; exec @ARGV or die "exec failed: $!"' \
+    -- "$SPCTL_TIMEOUT_SECONDS" spctl -a -vvv -t install "$BINARY" 2>&1)" || SPCTL_EXIT=$?
 if [ "$SPCTL_EXIT" -eq 142 ]; then
     # perl alarm exit code: 128 + SIGALRM (14) = 142
     echo "Error: spctl timed out after ${SPCTL_TIMEOUT_SECONDS}s." >&2


### PR DESCRIPTION
Refs #67, #69, #71, #72, #77

## Summary

Cluster of 5 Wave 2 verify follow-ups, all classified Simple by `/idd-diagnose`. Lands as 4 commits (#67 + #69 share a spec-sync commit). 208/208 tests still pass.

## Issues addressed

| # | Type | Files touched |
|---|---|---|
| **#72** | refactor / DRY | `Sources/CheICalMCP/Server.swift` |
| **#67** | spec / consistency | `openspec/specs/eventkit-error-sanitization/spec.md` |
| **#69** | hardening / spec | `openspec/specs/eventkit-error-sanitization/spec.md` + `Sources/CheICalMCP/EventKit/EventKitManager.swift` |
| **#71** | docs / convention | `CLAUDE.md` |
| **#77** | hardening / release-pipeline | `scripts/sign-and-notarize.sh` |

## Per-commit summary

### `21d186e` refactor: outer-catch delegates to writeFailureLog (#72)

The outer `handleToolCall` catch (Server.swift:996) inlined the same sanitize+escape+gate+write pattern that already lives inside `EventKitErrorSanitizer.writeFailureLog`. Two sites of the same logic forced any future hardening (#73 escapeForStderr ANSI/NUL coverage, #70 thread-safety) to be applied twice or risk drift. Replace with a single `writeFailureLog` call. Behavior identical:

- stderr line shape unchanged: `"handleToolCall(<name>) failed: <rawLog>\n"`
- wire response unchanged: `"Error: <code>"`
- #41 / R7 trusted-branch carve-out inherited from `writeFailureLog`

Also: `.claude/worktrees/` added to `.gitignore` (Claude Code agent worktrees were leaking).

### `6522fb1` spec+code: R3/R8 trusted-branch carve-out coverage (#67, #69)

**#67 (R8 spec amendment)**: outer catch now delegates to `writeFailureLog` (#72), so its trusted-branch stderr-skip is inherited rather than inlined. R8 spec wording reflects the delegation; new BDD scenario "Trusted error at outer catch skips stderr" pins the carve-out at the outer-catch boundary.

**#69 (R3 carve-out symmetry)**: `EventKitManager.deleteRemindersBatch:1409` used `sanitize(_:)` directly per R3 — but wrote stderr **unconditionally** for both trusted and untrusted errors. The R7 amendment (#41) closed the DoS amplification window for the 9 `writeFailureLog` sites + 1 EventKitManager site, but this 1 site escaped the cluster guarantee. Add the same `if !(error is TrustedErrorMessage)` gate. Spec.md R3 grows the "if and only if" wording + a new BDD scenario "Trusted error in deleteRemindersBatch skips stderr".

**Cluster intent**: post-#67+#69, every stderr write surface in the sanitizer cluster (R3, R7, R8) shares the same trusted-branch behavior — no asymmetric paths.

### `c1f7e4b` docs(CLAUDE.md): clarify `<Domain>Source` naming (#71)

The canonical example `reminderCleanupSource` conforms to `EventKitManaging` — a name that doesn't match the `<Domain>Source` rule the same section advertises. The next handler-test author sees a mismatch.

Add 2-line clarification: naming rule applies to **new** protocols going forward; `EventKitManaging` is grandfathered (per #31 narrow-protocol origin); the protocol-typed parameter name need not match the protocol's name. Per #71 diagnosis Option B (doc-only).

### `5a3838c` hardening: spctl timeout wrapper for OCSP hangs (#77)

The `[4/5]` spctl cross-check (added by PR #76, #53 fix) makes a network call to Apple's OCSP servers. If OCSP is slow or unreachable (corporate proxy filter, captive portal, transient outage, DNS stall), spctl hangs indefinitely. `set -e` doesn't help (process didn't exit), `|| true` doesn't help (process didn't terminate). `make release-signed` stalls with no diagnostic.

Wrap with `perl -e 'alarm shift; exec @ARGV' $SPCTL_TIMEOUT_SECONDS` — perl is always present on macOS, so zero-deps (avoids `brew install coreutils` requirement of GNU `timeout`). Detect timeout via exit code 142 (perl: 128 + SIGALRM 14) and surface a clear diagnostic. Default 60s; override via `SPCTL_TIMEOUT_SECONDS` env var.

Verified: `perl -e 'alarm 1; exec sleep 5'` returns exit 142 as expected on macOS 26.4.

## Verification

- ✅ `swift build` clean (Build complete! 21.52s)
- ✅ `swift test` 208/208 pass (CheICalMCPPackageTests.xctest)
- ✅ `bash -n scripts/sign-and-notarize.sh` syntax OK
- ✅ perl alarm semantics empirically verified (exit 142 on timeout)

## No new tests added (rationale)

#69 carve-out adds a 1-line gate that mirrors 9 existing gated sites in `writeFailureLog`. The existing test `testWriteFailureLogReturnValueDoesNotEscapeControlChars` (set at #41) already documented why stderr-skip behavior isn't unit-test-asserted: stderr capture in unit tests requires `FileHandle` redirection harness. R3 follows the same precedent — BDD scenarios in spec.md are the canonical record of new behavior.

## Out of scope

- #66 / #70 / #73 / #74 / #75 (Plan-warranted) — separate `/idd-plan` cycles.
- #68 (Deferred) — stays open with trigger conditions.
- stderr-capture test helper — pre-existing OOS; would benefit R3, R7, R8 uniformly when implemented.

## Related

- #65 (parent verify — spawned #66–#73)
- #76 (parent verify — spawned #77)
- #63 (parent verify — spawned #74; not in this cluster)
- #55 (parent verify — spawned #75; not in this cluster)
