### PR TITLE
docs(zh-TW): add rm -f preamble to install snippets (#90)

### DIFF
--- a/README_zh-TW.md
+++ b/README_zh-TW.md
@@ -83,6 +83,11 @@ claude plugin install che-ical-mcp@psychquant-claude-plugins
 mkdir -p ~/bin
 
 # 下載最新版本
+# 注意：升級時請先 `rm -f ~/bin/CheICalMCP`。沒做這步的話，
+# macOS 26 kernel 可能會拿舊 inode 的 stale code-signature
+# cache 殺掉新 binary（執行中的舊 MCP server processes 可能還
+# 持有那個 inode）— 這是 #62 修的升級陷阱。
+rm -f ~/bin/CheICalMCP
 curl -L https://github.com/PsychQuant/che-ical-mcp/releases/latest/download/CheICalMCP -o ~/bin/CheICalMCP
 chmod +x ~/bin/CheICalMCP
 
@@ -198,6 +203,8 @@ make release && make install
 
 1. 下載執行檔：
    ```bash
+   # 升級時先 rm -f 舊 binary（macOS 26 inode-reuse 簽章雜湊錯位陷阱，#62）
+   rm -f /usr/local/bin/che-ical-mcp
    curl -L https://github.com/PsychQuant/che-ical-mcp/releases/latest/download/CheICalMCP -o /usr/local/bin/che-ical-mcp
    chmod +x /usr/local/bin/che-ical-mcp
    ```
@@ -222,6 +229,8 @@ make release && make install
 mkdir -p ~/bin
 
 # 下載執行檔
+# 升級時先 rm -f 舊 binary（macOS 26 inode-reuse 簽章雜湊錯位陷阱，#62）
+rm -f ~/bin/CheICalMCP
 curl -L https://github.com/PsychQuant/che-ical-mcp/releases/latest/download/CheICalMCP -o ~/bin/CheICalMCP
 chmod +x ~/bin/CheICalMCP
 


### PR DESCRIPTION
Refs #90

## Summary

Add `rm -f` preamble to all 3 zh-TW install snippets in `README_zh-TW.md`. Surfaced by Devil's Advocate during #75 verify (PR #89 DA P3) — zh-TW had zero coverage of the macOS 26 inode-reuse / stale-code-signature SIGKILL trap that #62 added to one EN install snippet.

## Background

`#62` upgrade trap fix added `rm -f` to one EN install snippet (`README.md:90`, Claude Code Method B) because copying over an existing `~/bin/CheICalMCP` while old MCP processes still hold the inode causes the macOS 26 kernel to kill the new binary with `load code signature error 2 / Taskgated Invalid Signature` (the kernel caches code-signature hashes per-inode). The same threat model applies to ALL binary upgrade paths regardless of installation method.

zh-TW snippets at L86 / L201 / L225 had no `rm -f` preamble. This PR adds it to all 3 (defensive — broader than EN's current coverage of just L86-equivalent).

## Changes

Single file (`README_zh-TW.md`):

- **L85-91** — Claude Code Method B (`~/bin/CheICalMCP`): added 4-line Chinese comment block + `rm -f` line, mirroring EN structure
- **L205-209** — Claude Desktop Method 2 (`/usr/local/bin/che-ical-mcp`): added 1-line Chinese comment + `rm -f` line
- **L230-234** — Claude Code from-source (`~/bin/CheICalMCP`): added 1-line Chinese comment + `rm -f` line

## EN parity note

zh-TW now goes broader than EN — EN's L201/L225 path-equivalents in `README.md` ALSO lack `rm -f` (only L90 has it). The threat model applies to those paths too; suggesting a follow-up issue to harmonize EN if user agrees.

## Tests
N/A (docs-only change). `swift build` not affected.

## Checklist

- [x] Diagnose-by-filing (issue #90 was filed during #75 verify with full Strategy + Verification spec, no separate `/idd-diagnose` needed for a 9-line docs fix)
- [x] Implement (single commit, references #90)
- [ ] Verify (`/idd-verify #90 --pr <this-PR>`)
- [ ] `/idd-close #90` after merge

---

Generated by `/idd-implement #90 --pr` (single-issue PR mode). Per ralph "照妳覺得" delegation: complexity is "Simple" by inspection (3 mechanical edits, no decision-heavy boundary, single-file scope), executed atomic commit without separate `/idd-diagnose` ceremonial gate.
