### PR TITLE
ci: add PR-time test workflow (#51 Layer 1)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Show toolchain version
         run: |
@@ -54,7 +54,7 @@ jobs:
       # bulk of the runtime. Keyed on Package.resolved so cache invalidates
       # automatically on dependency upgrade.
       - name: Cache SPM .build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .build
           key: ${{ runner.os }}-spm-${{ hashFiles('Package.resolved') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,68 @@
+# PR-time test gate (#51 Layer 1)
+#
+# Runs `swift build` and `swift test` on every push and PR against main.
+# This is the minimum viable CI: catches "PR breaks the test suite" before
+# the maintainer manually runs `swift test` locally.
+#
+# Layer 2 (lint workflows: version-drift check #48, markdown lint, swift-format)
+# and Layer 3 (release automation: signing + notarization in CI requiring
+# .p12 cert export to GH Secrets — security trade-off) are deliberately
+# deferred per #51 Strategy. See #51 closing summary for trigger conditions
+# to expand this workflow.
+#
+# Runner: macos-latest is required because the test suite uses EventKit
+# (macOS-only Apple framework). Linux runners cannot satisfy `import EventKit`.
+# This pins the workflow's Apple-platform-only nature; cross-platform CI is
+# explicitly out of scope per #51 Out-of-scope clause.
+#
+# Security note: this workflow uses ONLY safe context expressions:
+# `github.workflow`, `github.ref`, `runner.os`, `hashFiles('Package.resolved')`.
+# It deliberately does NOT consume any untrusted input (issue/PR titles,
+# commit messages, branch names) in `run:` blocks — the per-blog-post
+# command-injection vector is closed by construction.
+
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Cancel in-progress runs on the same ref when a new commit lands. Saves
+# CI minutes on rapid push sequences (typical in IDD verify-fix loops).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: swift build + swift test
+    runs-on: macos-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Show toolchain version
+        run: |
+          swift --version
+          xcodebuild -version
+
+      # Cache .build/ — SPM dependency resolution + compilation is the
+      # bulk of the runtime. Keyed on Package.resolved so cache invalidates
+      # automatically on dependency upgrade.
+      - name: Cache SPM .build
+        uses: actions/cache@v4
+        with:
+          path: .build
+          key: ${{ runner.os }}-spm-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+
+      - name: swift build
+        run: swift build
+
+      - name: swift test
+        run: swift test

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,11 @@
 # Swift
 .build/
 .swiftpm/
-Package.resolved
+# Package.resolved IS tracked (executable target — Apple recommends
+# committing the lockfile so CI / contributors see the same transitive
+# dependency versions; untracked previously, restored 2026-05-07 per #51
+# verify which caught that GH Actions cache key hashing this file would
+# always hash an absent file → cache never invalidates on dep upgrade).
 
 # Python (legacy)
 __pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ Follow-ups from the PR #26 multi-agent review — hardening that extends the 1.7
 ### Known follow-up (tracked separately)
 - #32 _**(landed in this Unreleased window — see Security below)**_
 
+### Added
+- **`.github/workflows/test.yml` — PR-time test gate (#51 Layer 1)**: minimal CI workflow that runs `swift build` + `swift test` on every push/PR against `main`. Catches "PR breaks the test suite" before reviewer manual `swift test`. Runner pinned to `macos-latest` (EventKit is macOS-only). SPM `.build` cache keyed on `Package.resolved` for dependency-upgrade-aware invalidation. Concurrency group cancels in-progress runs on rapid push sequences. Layers 2 (lint workflows) + 3 (release automation with `.p12` cert in GH Secrets) deferred per #51 Strategy — see closing summary for trigger conditions.
+
 ### Documentation
 - **`writeFailureLog` + R3 inline-write thread-safety best-effort posture (#70)**: documented the actual concurrency property of the 11 `FileHandle.standardError.write` sites — POSIX `write(2)` only guarantees atomicity for byte counts ≤ macOS `PIPE_BUF` (**512 bytes**, NOT 4096; that's Linux). Failure-line shape `<handler>(<identifier>) failed: <safeRawLog>\n` exceeds 512 bytes for any non-trivial `NSError.localizedDescription` (`maxRawLogChars` is 1024 chars alone). Concurrent `async` failing-tool-call races therefore CAN interleave on stderr; operators must NOT rely on `tail -f stderr | parse-by-line` producing perfectly framed records. Serial actor option (Option A — `StderrLogger.shared`) deferred — at this server's single-client concurrency profile, the contention window is narrow enough that touching every catch handler with `await` propagation exceeds the observability value. **Trigger to revisit Option A**: multi-tenant deployment / SRE interleaving complaint / structured stderr becoming load-bearing / `#66` periodic-summary mechanism. See `#70` closing summary for full deferral rationale.
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,68 @@
+{
+  "pins" : [
+    {
+      "identity" : "eventsource",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/eventsource.git",
+      "state" : {
+        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "8d9834a6189db730f6264db7556a7ffb751e99ee",
+        "version" : "1.4.0"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "bbd81b6725ae874c69e9b8c8804d462356b55523",
+        "version" : "1.10.1"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "b31565862a8f39866af50bc6676160d8dda7de35",
+        "version" : "2.96.0"
+      }
+    },
+    {
+      "identity" : "swift-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/modelcontextprotocol/swift-sdk.git",
+      "state" : {
+        "revision" : "6132fd4b5b4217ce4717c4775e4607f5c3120129",
+        "version" : "0.12.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
+        "version" : "1.6.4"
+      }
+    }
+  ],
+  "version" : 2
+}


### PR DESCRIPTION
Refs #51

## Summary

Add `.github/workflows/test.yml` — minimum viable CI workflow per #51 Layer 1 strategy. Runs `swift build` + `swift test` on every push and PR against `main`. Catches "PR breaks test suite" before reviewer manual `swift test`.

## Background

`#51` issue body framed CI/CD as 3 layers:
- **Layer 1** — PR-time CI (test on push/PR) — **smallest cost, biggest immediate value**
- **Layer 2** — Lint workflows (version drift #48, markdown lint, swift-format)
- **Layer 3** — Release automation (signing + notarization in CI, requires `.p12` cert in GH Secrets — security trade-off)

Per ralph delegation, this PR ships **Layer 1 only**. Layer 2/3 deferred with trigger conditions in closing summary.

## Design choices

- **Runner**: `macos-latest` — EventKit is macOS-only, Linux runners cannot satisfy `import EventKit`. Cross-platform CI explicitly out of scope per #51.
- **Cache**: SPM `.build/` keyed on `Package.resolved`. Auto-invalidates on dependency upgrade. Fallback restore key for partial cache hits.
- **Concurrency**: `cancel-in-progress: true` on same ref. Saves CI minutes during rapid push sequences (typical in IDD verify-fix loops).
- **Timeout**: 20 min. Empirical: pre-#83 baseline was ~3 min cold cache, ~30s warm; 20 min safety margin for swift compiler regressions.
- **Triggers**: push to `main` + PRs targeting `main`. (Feature branches still get verified via PR open.)

## Security note

Uses ONLY safe context expressions:
- `github.workflow` (workflow name — static)
- `github.ref` (branch ref — Git-validated)
- `runner.os` (runtime constant)
- `hashFiles('Package.resolved')` (file content hash — no string interpolation)

Deliberately does NOT consume untrusted input (issue/PR titles, commit messages, branch names) in `run:` blocks. Command-injection vector closed by construction per [GitHub blog Workflow injection guide](https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/).

## Layer 2 / 3 deferred — trigger conditions

Layer 2 (lint workflows) and Layer 3 (release automation) deferred per #51 Strategy because:

- **Layer 2 trigger**: when CHANGELOG / `Version.swift` / `Info.plist` / `manifest.json` drift is observed in actual review (not theoretical). #48 lint check would catch.
- **Layer 3 trigger**: when bus factor becomes acute (only maintainer can release; ≥2 contributors with cert access need to coordinate; CI signing + notarization avoids per-machine cert proliferation). Major investment: `.p12` cert export, GH Secret management, notarytool keychain profile in CI runner — security review needed first.

## Tests

- N/A for CI workflow itself (this IS the test infrastructure)
- Existing 226 tests will run on this PR via the new workflow → first time we'll see a green CI badge

## Checklist

- [x] Diagnose-by-issue-body (Strategy was already spelled out as Layer 1/2/3)
- [x] Implement Layer 1 (single commit, references #51)
- [~] Layer 2 — deferred with trigger condition
- [~] Layer 3 — deferred with trigger condition
- [ ] Verify (`/idd-verify #51 --pr <this-PR>`)
- [ ] `/idd-close #51` after merge

---

Generated by `/idd-implement #51 --pr` (single-issue PR mode). Per ralph "照妳覺得" delegation: implementing Layer 1 only with explicit deferral of Layer 2/3 + trigger conditions.
