### PR TITLE
feat(make): add install-signed target for maintainer dev TCC flow on macOS 26 (#50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Follow-ups from the PR #26 multi-agent review — hardening that extends the 1.7
 - #32 _**(landed in this Unreleased window — see Security below)**_
 
 ### Added
+- **`make install-signed` Makefile target (#50)**: Developer ID + hardened runtime signature WITHOUT notarization for fast maintainer dev iteration. Solves the macOS 26 TCC dogfood gap — ad-hoc signed binaries (`make install`) can't trigger Calendar / Reminders permission dialogs on macOS 26, breaking the maintainer's `--setup` flow verification. Trade-offs vs `release-signed`: signed-but-not-notarized → Gatekeeper online-checks on first launch (one-time stutter), suitable for maintainer dogfood / TCC flow verification on macOS 26, NOT for distribution to other users. Pre-condition: `DEVELOPER_ID` exported (`NOTARY_PROFILE` unused — no notarytool step).
 - **`.github/workflows/test.yml` — PR-time test gate (#51 Layer 1)**: minimal CI workflow that runs `swift build` + `swift test` on every push/PR against `main`. Catches "PR breaks the test suite" before reviewer manual `swift test`. Runner pinned to `macos-latest` (EventKit is macOS-only). SPM `.build` cache keyed on `Package.resolved` for dependency-upgrade-aware invalidation. Concurrency group cancels in-progress runs on rapid push sequences. Layers 2 (lint workflows) + 3 (release automation with `.p12` cert in GH Secrets) deferred per #51 Strategy — see closing summary for trigger conditions.
 
 ### Documentation

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BINARY_NAME := CheICalMCP
 # Remove FALLBACK_FLAGS once the upstream issue is fixed.
 FALLBACK_FLAGS := $(shell swift build 2>&1 | grep -q "SendingRisksDataRace" && echo "-Xswiftc -swift-version -Xswiftc 5")
 
-.PHONY: build release release-signed verify-release-ready install install-signed clean test
+.PHONY: build release release-signed verify-release-ready verify-developer-id install install-signed clean test
 
 # Detect drift between AppVersion.current and the latest release tag.
 # Soft pre-flight: warns on drift, never aborts on the drift case (a maintainer
@@ -107,9 +107,21 @@ install: release
 #
 # Pre-condition: same as `release-signed` — `DEVELOPER_ID` exported in env.
 # `NOTARY_PROFILE` is NOT required (no notarization step).
-install-signed: release
+#
+# `verify-developer-id` runs FIRST (before `release`) so a missing
+# DEVELOPER_ID env var aborts BEFORE the ~30-second `swift build -c release`
+# (#50 verify Codex caught: original placement let the DEVELOPER_ID check
+# fire only after build, wasting the user's iteration time on a guaranteed
+# failure).
+
+# Internal helper target: hard-fail early if DEVELOPER_ID env var is missing.
+# Listed in .PHONY since it produces no file. Used as a left-most dep on
+# `install-signed` so make resolves it before the `release` build dep.
+verify-developer-id:
 	@: $${DEVELOPER_ID:?DEVELOPER_ID not set. See README 'Signing & Notarization' for setup. \
 	   For dev install on macOS 26 you only need DEVELOPER_ID — NOTARY_PROFILE is unused here.}
+
+install-signed: verify-developer-id release
 	rm -f ~/bin/$(BINARY_NAME)
 	cp .build/release/$(BINARY_NAME) ~/bin/$(BINARY_NAME)
 	chmod +x ~/bin/$(BINARY_NAME)

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BINARY_NAME := CheICalMCP
 # Remove FALLBACK_FLAGS once the upstream issue is fixed.
 FALLBACK_FLAGS := $(shell swift build 2>&1 | grep -q "SendingRisksDataRace" && echo "-Xswiftc -swift-version -Xswiftc 5")
 
-.PHONY: build release release-signed verify-release-ready install clean test
+.PHONY: build release release-signed verify-release-ready install install-signed clean test
 
 # Detect drift between AppVersion.current and the latest release tag.
 # Soft pre-flight: warns on drift, never aborts on the drift case (a maintainer
@@ -85,6 +85,42 @@ install: release
 	chmod +x ~/bin/$(BINARY_NAME)
 	codesign --force --sign - ~/bin/$(BINARY_NAME)
 	@echo "Installed: ~/bin/$(BINARY_NAME) (ad-hoc signed — dev only)"
+
+# Dev install with Developer ID signature (no notarization). Slower than
+# `make install` (Developer ID round-trip vs ad-hoc), but **fast enough for
+# dev iteration**: skips the notarytool submit step (1-15 min waits) that
+# `make release-signed` adds for distribution.
+#
+# Why this target exists (#50): on macOS 26, ad-hoc signed binaries cannot
+# trigger TCC permission dialogs (Calendar / Reminders). Maintainers
+# dogfooding `--setup` flows on their own machine need a Developer ID
+# signature to test the macOS 26 TCC interaction. `make install` (ad-hoc)
+# is too weak; `make release-signed` (full notarization, distribution-ready)
+# is overkill — this target is the middle ground.
+#
+# Trade-offs vs release-signed:
+#   - SIGNED with Developer ID + hardened runtime → TCC dialogs work
+#   - NOT notarized → Gatekeeper online-checks on first launch may stutter
+#     (one-time network hit), but the binary IS launchable on the dev machine
+#   - Suitable for: maintainer dogfood, TCC flow verification on macOS 26
+#   - NOT suitable for: distribution to other users (notarization required)
+#
+# Pre-condition: same as `release-signed` — `DEVELOPER_ID` exported in env.
+# `NOTARY_PROFILE` is NOT required (no notarization step).
+install-signed: release
+	@: $${DEVELOPER_ID:?DEVELOPER_ID not set. See README 'Signing & Notarization' for setup. \
+	   For dev install on macOS 26 you only need DEVELOPER_ID — NOTARY_PROFILE is unused here.}
+	rm -f ~/bin/$(BINARY_NAME)
+	cp .build/release/$(BINARY_NAME) ~/bin/$(BINARY_NAME)
+	chmod +x ~/bin/$(BINARY_NAME)
+	codesign --force \
+	         --sign "$$DEVELOPER_ID" \
+	         --options runtime \
+	         --entitlements Sources/CheICalMCP/Entitlements.plist \
+	         ~/bin/$(BINARY_NAME)
+	@echo "Installed: ~/bin/$(BINARY_NAME) (Developer ID signed, NOT notarized — dev only)"
+	@echo "ℹ macOS 26 TCC dialogs WILL trigger because the binary has Developer ID + hardened runtime."
+	@echo "ℹ For distribution to other users, use 'make release-signed' instead (adds notarization)."
 
 test:
 	swift test $(FALLBACK_FLAGS)


### PR DESCRIPTION
Refs #50

## Summary

Add `make install-signed` Makefile target — Developer ID + hardened runtime signature WITHOUT notarization for fast maintainer dev iteration on macOS 26.

## Background

`make install` (existing) uses ad-hoc signing (`codesign --force --sign -`) for fast dev iteration. On macOS 26 this is broken for the maintainer's TCC dogfood workflow:

- Ad-hoc signed binaries **cannot trigger TCC permission dialogs** (Calendar, Reminders) on macOS 26
- Maintainer running `CheICalMCP --setup` on their dev machine never sees the permission UI
- Forgetting and shipping a release that "works for me" but breaks for users (the v1.7.0 → v1.7.1 failure mode that motivated #44 in the first place) becomes likely

`make release-signed` (full notarization) is overkill for dev — adds 1-15 min `notarytool submit --wait` round-trip per iteration.

## Solution

`make install-signed` is the middle ground:
- Developer ID signature + hardened runtime → TCC dialogs trigger ✓
- NOT notarized → no notarytool round-trip; ~2 sec instead of 1-15 min
- Gatekeeper online-checks on first launch (one-time stutter on dev machine; acceptable)

## Trade-offs

| Target | Signature | Notarized | Speed | Use case |
|--------|-----------|-----------|-------|----------|
| `make install` | Ad-hoc (`-`) | No | ~3s | Dev iteration on macOS ≤25 |
| **`make install-signed`** (new) | Developer ID | No | ~5s | **Dev iteration on macOS 26 (TCC flows)** |
| `make release-signed` | Developer ID | Yes | ~5-15min | Distribution to other users |

## Pre-conditions

- `DEVELOPER_ID` env var exported (same as `release-signed`)
- `NOTARY_PROFILE` is **NOT** required (no notarytool submit step)
- `Sources/CheICalMCP/Entitlements.plist` exists (already in repo per #44)

## Changes

- `Makefile` — new `install-signed` target + `.PHONY` update
- `CHANGELOG.md` — `[Unreleased] → ### Added` entry

## Tests

- `make -n install-signed` (dry-run) — Makefile syntax valid; target reachable
- Behavior change is target-only; no source code or test changes

## Checklist

- [x] Diagnose-by-issue-body (Strategy was already spelled out as 4 options; chose Option 1)
- [x] Implement (single commit, references #50)
- [ ] Verify (`/idd-verify #50 --pr <this-PR>`)
- [ ] `/idd-close #50` after merge

---

Generated by `/idd-implement #50 --pr` (single-issue PR mode). Per ralph "照妳覺得" delegation: chose Option 1 (Makefile signed-install target) per maintainer answer to AskUserQuestion.
