### PR TITLE
cluster: mcpb pack artifact hygiene + version-stamped output (#111 #112)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ mcpb/server/*
 
 # MCPB package (generated)
 mcpb/*.mcpb
+mcpb/*.mcpb.sha256
 
 # Private docs (not for public repo)
 docs/private/

--- a/mcpb/.mcpbignore
+++ b/mcpb/.mcpbignore
@@ -1,8 +1,11 @@
 # mcpb pack ignore (#111)
 # mcpb/ doubles as both the `mcpb pack` source dir and the build output dir.
-# Without this, every release bundles the PREVIOUS versions' release artifacts
-# (*.mcpb / *.mcpb.sha256) into the new archive — monotonic accumulation, and
-# end users open vX.Y.Z.mcpb to find a confusing v(X.Y.Z-1).mcpb.sha256 inside.
+# The load-bearing line is *.mcpb.sha256: mcpb 2.1.2's built-in EXCLUDE_PATTERNS
+# already drops *.mcpb, but NOT the companion *.mcpb.sha256 — so without this,
+# each release leaks the previous version's lone .mcpb.sha256 into the new archive
+# (end users open vX.Y.Z.mcpb to find a stray v(X.Y.Z-1).mcpb.sha256 inside).
+# *.mcpb is kept as explicit defense-in-depth: redundant with the built-in default
+# today, but makes intent clear and survives a future mcpb that drops the default.
 # Verified: mcpb 2.1.2 honors this file (pack prints "ignored (.mcpbignore) files: N").
 *.mcpb
 *.mcpb.sha256

--- a/mcpb/.mcpbignore
+++ b/mcpb/.mcpbignore
@@ -1,0 +1,8 @@
+# mcpb pack ignore (#111)
+# mcpb/ doubles as both the `mcpb pack` source dir and the build output dir.
+# Without this, every release bundles the PREVIOUS versions' release artifacts
+# (*.mcpb / *.mcpb.sha256) into the new archive — monotonic accumulation, and
+# end users open vX.Y.Z.mcpb to find a confusing v(X.Y.Z-1).mcpb.sha256 inside.
+# Verified: mcpb 2.1.2 honors this file (pack prints "ignored (.mcpbignore) files: N").
+*.mcpb
+*.mcpb.sha256

--- a/scripts/build-mcpb.sh
+++ b/scripts/build-mcpb.sh
@@ -265,10 +265,17 @@ echo ""
 if command -v mcpb &> /dev/null; then
     echo "Packing MCPB bundle..."
     cd "$MCPB_DIR"
-    mcpb pack
+    # Pack with an explicit, version-stamped output name (#112). `mcpb pack`
+    # otherwise derives the output filename from the source dir name → mcpb/mcpb.mcpb,
+    # forcing a manual rename every release. .mcpbignore (#111) keeps prior
+    # versions' artifacts out of the archive.
+    PACKED="che-ical-mcp-${SOURCE_VERSION}.mcpb"
+    mcpb pack . "$PACKED"
+    shasum -a 256 "$PACKED" | awk '{print $1}' > "${PACKED}.sha256"
     echo ""
     echo "=== Build Complete ==="
-    echo "MCPB package: $MCPB_DIR/che-ical-mcp.mcpb"
+    echo "MCPB package: $MCPB_DIR/$PACKED"
+    echo "SHA-256:      $MCPB_DIR/${PACKED}.sha256"
 else
     echo "=== Build Complete (Manual Pack Required) ==="
     echo "mcpb CLI not found. To pack the bundle:"

--- a/scripts/build-mcpb.sh
+++ b/scripts/build-mcpb.sh
@@ -280,7 +280,7 @@ else
     echo "=== Build Complete (Manual Pack Required) ==="
     echo "mcpb CLI not found. To pack the bundle:"
     echo "  1. Install: npm install -g @anthropic-ai/mcpb"
-    echo "  2. Run: cd mcpb && mcpb pack"
+    echo "  2. Run: cd mcpb && mcpb pack . \"che-ical-mcp-${SOURCE_VERSION}.mcpb\""
 fi
 
 echo ""


### PR DESCRIPTION
Refs #111
Refs #112

## Summary
mcpb release-pipeline hygiene (cluster #111 + #112, shared `scripts/build-mcpb.sh` + `mcpb/`):
- **#111**: stop bundling prior-version artifacts (`*.mcpb` / `*.mcpb.sha256`) into the new `.mcpb` archive
- **#112**: version-stamped `mcpb pack` output filename (no manual rename per release)

## Changes (1 commit)
- `mcpb/.mcpbignore` — exclude `*.mcpb` / `*.mcpb.sha256` (verified mcpb 2.1.2 honors it; `--help` doesn't list it but pack prints `ignored (.mcpbignore) files: N`)
- `.gitignore` — also ignore `mcpb/*.mcpb.sha256` (was only `*.mcpb`)
- `scripts/build-mcpb.sh` — `mcpb pack . "che-ical-mcp-${SOURCE_VERSION}.mcpb"` + generate `.sha256` + accurate "Build Complete" echo

## Verification (mechanism-tested 2026-05-29)
- output param → versioned filename (not `mcpb.mcpb`) ✓
- cleanup-glob safety: `server/CheICalMCP.sha256` preserved ✓
- clean archive: no stale artifact, no self-inclusion ✓
- `.mcpbignore` honored by mcpb 2.1.2 ✓
- `bash -n build-mcpb.sh` ✓; `SOURCE_VERSION` (line 41) in scope at pack site ✓

## Out of scope (filed separately)
- **#138** — mcpb 2.1.2 rejects current manifest's `compatibility.runtimes.macos` → `mcpb pack` fails on the real manifest (independently blocks release). Surfaced during this work; scope-guarded into its own issue.

## Checklist
- [x] Diagnose (#111 #112)
- [x] Implement (1 commit)
- [ ] Verify (`/idd-verify #111 #112`)
- [x] Verify-gated: post-verify PASS → `/idd-close #111 #112` after merge

---
**Do NOT add a close trailer** (Closes/Fixes/Resolves) — IDD requires manual `/idd-close` after merge to enforce checklist gate + closing summary.
