### PR TITLE
cluster: #131 verify P4 follow-ups — escape --setup error (#146) + robust isNonInteractive test (#147)

### DIFF
--- a/Sources/CheICalMCP/main.swift
+++ b/Sources/CheICalMCP/main.swift
@@ -119,7 +119,12 @@ if CommandLine.arguments.contains("--setup") {
                 print("\(label) access: \(granted ? "✓ granted" : "✗ denied")")
                 if !granted { anyBlockedOrDenied = true }
             } catch {
-                print("\(label) access: ✗ error — \(error.localizedDescription)")
+                // Escape the framework error text at the stdout boundary, matching the
+                // discipline in TCCDriftDetector / SelfUpdate (#146). First-party EventKit
+                // source, but control chars (NUL / ANSI) in localizedDescription should not
+                // pass through raw to a terminal.
+                let safe = EventKitErrorSanitizer.escapeForStderr(error.localizedDescription)
+                print("\(label) access: ✗ error — \(safe)")
                 anyBlockedOrDenied = true
             }
         case .skipWouldBlock:

--- a/Tests/CheICalMCPTests/SetupCommandTests.swift
+++ b/Tests/CheICalMCPTests/SetupCommandTests.swift
@@ -52,14 +52,19 @@ final class SetupCommandTests: XCTestCase {
     // MARK: - Non-Interactive Detection
 
     func testIsNonInteractiveDetection() {
-        // Test runner runs from Xcode/Terminal with TERM set, so should not be non-interactive.
-        // Note: CI environments may differ — this test validates the local dev experience.
-        let hasTerm = ProcessInfo.processInfo.environment["TERM"] != nil
-        if hasTerm {
-            XCTAssertFalse(
-                EventKitManager.isNonInteractive,
-                "Test runner with TERM set should not be detected as non-interactive")
-        }
+        // `isNonInteractiveSession` = getppid()==1 || TERM==nil || CI!=nil (#131).
+        // A `TERM`-set guard alone is NOT sufficient to expect `false` — if `CI` is
+        // also set (`CI=1 swift test` locally, or a CI runner that sets TERM), the
+        // session is still non-interactive. Mirror the full production contract so
+        // the assertion is robust to env (#147 — previously only passed on GHA because
+        // GHA leaves TERM unset, which silently skipped the assertion).
+        let env = ProcessInfo.processInfo.environment
+        let expectedNonInteractive =
+            getppid() == 1 || env["TERM"] == nil || env["CI"] != nil
+        XCTAssertEqual(
+            EventKitManager.isNonInteractive,
+            expectedNonInteractive,
+            "isNonInteractive must reflect getppid()==1 || TERM==nil || CI!=nil — robust to CI env")
     }
 
     // MARK: - Error Messages


### PR DESCRIPTION
Refs #146 #147

## Summary
Two P4 pre-existing follow-ups surfaced by the #131-cluster verify, bundled (same `--setup` / non-interactive test surface):

- **#146** (`b40ecff`): `--setup`'s requestAccess catch arm printed raw `error.localizedDescription` to stdout, unlike TCCDriftDetector / SelfUpdate which route framework error text through `EventKitErrorSanitizer.escapeForStderr`. Wrapped it for consistency — control chars (NUL / ANSI) in the (first-party EventKit) error text no longer pass through raw.
- **#147** (`e572fec`): `testIsNonInteractiveDetection` asserted `isNonInteractive==false` whenever `TERM` is set, but `isNonInteractiveSession` also includes `CI!=nil` (#131). Failed under `CI=1` + TERM; only passed on GHA because GHA leaves TERM unset. Now mirrors the full production contract — robust to env.

## Verification
- Local: 391 tests, 0 failures. #147 verified to pass under **both** plain `swift test` and `CI=1 swift test`.
- 6-AI cluster verify pending (`/idd-verify --pr <N>`).

## Checklist
- [x] Diagnose (#146 #147, both Simple)
- [x] Implement (2 commits, Refs discipline)
- [ ] Verify (run /idd-verify --pr <N>)
- [x] **Verify-gated**: post-verify PASS = ready to merge → /idd-close per issue after merge

---
Generated by /idd-all cluster path. **No GitHub close trailer** — IDD requires manual /idd-close per issue after merge.
