### PR TITLE
fix(drift): align pathHasControlChars with escapeForStderr C1 coverage (#152)

### DIFF
--- a/Sources/CheICalMCP/EventKit/TCCDriftDetector.swift
+++ b/Sources/CheICalMCP/EventKit/TCCDriftDetector.swift
@@ -264,12 +264,20 @@ struct TCCDriftDetector {
         return "'\(escaped)'"
     }
 
-    /// Returns true if the input contains any C0 control character (`\x00..\x1F`,
-    /// `\x7F` DEL). Used to gate the copy-paste actionable command (verify round-2
-    /// R1) — control chars inside single-quoted shell strings would split the
-    /// banner line on stderr, regardless of POSIX shell quoting semantics.
+    /// Returns true if the input contains any control character: C0 (`\x00..\x1F`),
+    /// DEL (`\x7F`), or the C1 band (`\x80..\x9F`). Used to gate the copy-paste
+    /// actionable command (verify round-2 R1) — control chars inside single-quoted
+    /// shell strings would split the banner line on stderr, regardless of POSIX
+    /// shell quoting semantics.
+    ///
+    /// The C1 band matches `EventKitErrorSanitizer.escapeForStderr`'s control-char
+    /// definition (#150 / #152) so the gate and the escaper cannot diverge: a C1
+    /// char (e.g. 8-bit CSI `\x9B`) in the running binary's path must NOT slip
+    /// unescaped into the `shellSingleQuote` command branch. Printable scalars
+    /// resume at `\xA0` (NBSP), so the C1 range is control-only.
     static func pathHasControlChars(_ s: String) -> Bool {
-        for scalar in s.unicodeScalars where scalar.value < 0x20 || scalar.value == 0x7F {
+        for scalar in s.unicodeScalars
+        where scalar.value < 0x20 || scalar.value == 0x7F || (0x80...0x9F).contains(scalar.value) {
             return true
         }
         return false

--- a/Tests/CheICalMCPTests/TCCDriftDetectorTests.swift
+++ b/Tests/CheICalMCPTests/TCCDriftDetectorTests.swift
@@ -546,6 +546,16 @@ final class TCCDriftDetectorTests: XCTestCase {
         XCTAssertTrue(TCCDriftDetector.pathHasControlChars("/path/with\u{7F}DEL"))
         XCTAssertTrue(TCCDriftDetector.pathHasControlChars("/path/with\tab"))
         XCTAssertFalse(TCCDriftDetector.pathHasControlChars(""))
+        // #152 — C1 control band (0x80-0x9F) must be detected, matching
+        // escapeForStderr's #150 definition. The 8-bit CSI (0x9B) is the
+        // load-bearing case (alternate form of ESC [).
+        XCTAssertTrue(TCCDriftDetector.pathHasControlChars("/path/with\u{80}C1start"))
+        XCTAssertTrue(TCCDriftDetector.pathHasControlChars("/path/with\u{9B}CSI"))
+        XCTAssertTrue(TCCDriftDetector.pathHasControlChars("/path/with\u{9F}C1end"))
+        // Boundary: NBSP (0xA0, first printable above C1) must NOT trip the gate.
+        XCTAssertFalse(TCCDriftDetector.pathHasControlChars("/path/with\u{A0}nbsp"))
+        // Printable Unicode (accents / CJK) above C1 must pass.
+        XCTAssertFalse(TCCDriftDetector.pathHasControlChars("/Users/José/中文/CheICalMCP"))
     }
 
     /// B3 fix: paths with shell-special characters in the runtime path land in the


### PR DESCRIPTION
Refs #152

## Summary
Aligns `TCCDriftDetector.pathHasControlChars` with the C1 control-char coverage that #150 added to `EventKitErrorSanitizer.escapeForStderr`. The gate (which decides whether a running-binary path may enter the `shellSingleQuote` copy-paste command) recognized only C0+DEL, so a C1 char (8-bit CSI `\x9B`) in the path could slip into the shell command line unescaped. Now both share the C0+DEL+C1 definition; printable scalars resume at `\xA0`, so the C1 range is control-only.

## Verification
- Local: 398 tests, 0 failures. Test extended with C1 band (`0x80`/`0x9B`/`0x9F`), the `0xA0` NBSP boundary (false), and accent/CJK passthrough.
- 6-AI verify pending.

## Checklist
- [x] Diagnose (Simple)
- [x] Implement (1 commit, Refs discipline)
- [ ] Verify
- [x] **Verify-gated**: post-verify PASS = ready to merge → run `/idd-close` on this issue after merge

---
Generated by /idd-all. **No GitHub close trailer** — IDD requires manual closing via the idd-close skill after merge to enforce the checklist gate + closing summary.
