### PR TITLE
fix: validate start<end in createEvent, symmetric with updateEvent (#160)

### DIFF
--- a/Sources/CheICalMCP/EventKit/EventKitManager.swift
+++ b/Sources/CheICalMCP/EventKit/EventKitManager.swift
@@ -379,6 +379,23 @@ actor EventKitManager: EventKitManaging {
         return eventStore.events(matching: predicate)
     }
 
+    /// Validates that a timed event's start is strictly before its end.
+    ///
+    /// All-day events are exempt (their day-range / same-instant representation is valid).
+    /// Shared by `createEvent` and `updateEvent` so both reject inverted / zero-duration
+    /// timed events consistently — previously only `updateEvent` guarded this, letting
+    /// `createEvent` persist invalid events (#160).
+    ///
+    /// - Parameter hint: optional caller-specific guidance appended to the error message
+    ///   (e.g. `updateEvent`'s "provide both start_time and end_time" advice).
+    static func validateTimeRange(start: Date, end: Date, isAllDay: Bool, hint: String? = nil) throws {
+        guard start >= end, !isAllDay else { return }
+        let formatter = ISO8601DateFormatter()
+        var message = "Start time (\(formatter.string(from: start))) must be before end time (\(formatter.string(from: end)))."
+        if let hint { message += " " + hint }
+        throw EventKitError.invalidTimeRange(message: message)
+    }
+
     func createEvent(
         title: String,
         startDate: Date,
@@ -395,6 +412,9 @@ actor EventKitManager: EventKitManaging {
         timezone: TimeZone? = nil
     ) async throws -> CreateEventResult {
         try await ensureCalendarAccess()
+
+        // Reject inverted / zero-duration timed events (symmetric with updateEvent — #160).
+        try Self.validateTimeRange(start: startDate, end: endDate, isAllDay: isAllDay)
 
         // Resolve calendar first (required for both duplicate check and creation)
         guard let name = calendarName else {
@@ -539,15 +559,13 @@ actor EventKitManager: EventKitManaging {
             event.endDate = newEnd
         }
 
-        // Validate time range
-        if event.startDate >= event.endDate && !event.isAllDay {
-            let dateFormatter = ISO8601DateFormatter()
-            let startStr = dateFormatter.string(from: event.startDate)
-            let endStr = dateFormatter.string(from: event.endDate)
-            throw EventKitError.invalidTimeRange(
-                message: "Start time (\(startStr)) must be before end time (\(endStr)). When changing the date, provide both start_time and end_time."
-            )
-        }
+        // Validate time range (shared guard with createEvent — #160)
+        try Self.validateTimeRange(
+            start: event.startDate,
+            end: event.endDate,
+            isAllDay: event.isAllDay,
+            hint: "When changing the date, provide both start_time and end_time."
+        )
 
         if let n = notes { event.notes = n }
         if let l = location { event.location = l }

--- a/Tests/CheICalMCPTests/TimeValidationTests.swift
+++ b/Tests/CheICalMCPTests/TimeValidationTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import Foundation
+@testable import CheICalMCP
 
 /// Tests for time validation logic in event updates
 /// These tests verify the fix for the update_event bug where
@@ -126,5 +127,51 @@ final class TimeValidationTests: XCTestCase {
         // This is a valid case for all-day events
         let startOfDay = calendar.startOfDay(for: date)
         XCTAssertEqual(startOfDay, calendar.startOfDay(for: date), "All-day events can have same start and end")
+    }
+
+    // MARK: - validateTimeRange production guard (#160)
+    // These exercise the real shared guard (not mirrored arithmetic), so create_event
+    // and update_event are proven to reject inverted / zero-duration timed events
+    // consistently. All-day events are exempt.
+
+    private func date160(_ hour: Int, _ minute: Int = 0) -> Date {
+        Calendar.current.date(from: DateComponents(
+            year: 2026, month: 1, day: 31, hour: hour, minute: minute
+        ))!
+    }
+
+    func testValidateTimeRange_endBeforeStart_timed_throws() {
+        XCTAssertThrowsError(
+            try EventKitManager.validateTimeRange(start: date160(15), end: date160(14), isAllDay: false)
+        ) { error in
+            guard case EventKitError.invalidTimeRange = error else {
+                return XCTFail("expected EventKitError.invalidTimeRange, got \(error)")
+            }
+        }
+    }
+
+    func testValidateTimeRange_endEqualsStart_timed_throws() {
+        // The #160 zero-duration case: create_event previously accepted this silently.
+        let t = date160(14)
+        XCTAssertThrowsError(
+            try EventKitManager.validateTimeRange(start: t, end: t, isAllDay: false)
+        ) { error in
+            guard case EventKitError.invalidTimeRange = error else {
+                return XCTFail("expected EventKitError.invalidTimeRange, got \(error)")
+            }
+        }
+    }
+
+    func testValidateTimeRange_allDay_endEqualsStart_doesNotThrow() {
+        let t = date160(0)
+        XCTAssertNoThrow(
+            try EventKitManager.validateTimeRange(start: t, end: t, isAllDay: true)
+        )
+    }
+
+    func testValidateTimeRange_endAfterStart_timed_doesNotThrow() {
+        XCTAssertNoThrow(
+            try EventKitManager.validateTimeRange(start: date160(14), end: date160(15), isAllDay: false)
+        )
     }
 }


### PR DESCRIPTION
## Summary
Refs #160. `createEvent` lacked the start < end time-range validation that `updateEvent` already had. The asymmetry let `create_event` persist inverted / zero-duration timed events that `update_event` rejects.

## Approach — Direction A (symmetric validation)
- New shared static `EventKitManager.validateTimeRange(start:end:isAllDay:hint:)` — throws `EventKitError.invalidTimeRange` when `start >= end && !isAllDay`. All-day events exempt.
- `createEvent`: calls it before `save`.
- `updateEvent`: inline guard (line 543) replaced with the shared call; original error message preserved via the `hint` parameter (behavior unchanged).

## Tests (TDD)
- `TimeValidationTests` now exercises the **real shared guard** (not mirrored arithmetic): end < start throws, end == start (the #160 zero-duration case) throws, all-day same-time does not throw, end > start does not throw.
- Full suite: **405 tests, 0 failures**.

## Out of scope
- Direction B (supporting 0-duration time-point events by relaxing the guard) — that is a feature with unverified EventKit persistence behavior; should be a separate issue.

Diagnosis + plan: see #160 comments.

