### PR TITLE
docs: README troubleshooting — Claude Code update-rotation TCC breakage (#170)

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,7 @@ If ambiguity is detected, the error message will list all available sources.
 | **Permission denied over SSH** | See [SSH Access](#ssh-access) below |
 | **Permission denied under launchd** | See [launchd / Automation](#launchd--automation) below |
 | **One service denied while every diagnostic reports green** | See [Silent permanent denial after upgrade](#silent-permanent-denial-after-upgrade-154) below |
+| **Calendar/Reminders break again after every Claude Code update** | See [Claude Code updates rotate the host-side grant](#claude-code-updates-rotate-the-host-side-grant-170) below |
 | Calendar not found | Ensure the calendar is visible in macOS Calendar app |
 | Reminders not syncing | Check iCloud sync in System Settings |
 
@@ -447,6 +448,12 @@ As of **v1.14.0+ the startup banner surfaces this directly** — a `[drift] TCC.
 **Fix**: upgrade to **v1.11.0 or later** (the binary now ships both entitlements), restart the host app (full `Cmd+Q` for Claude Desktop), and approve the permission dialog that appears on the first Calendar/Reminders access. Approving rewrites the TCC row keyed to the Developer ID requirement, so it survives all future upgrades. If you accidentally **deny** the dialog, re-enable the corresponding toggle in System Settings → Privacy & Security → Calendars or Reminders.
 
 > ⚠️ **Erratum for the #108-era workaround**: `tccutil reset Calendar com.checheng.CheICalMCP` does **not** work for a bare (non-bundled) binary — it fails with `OSStatus error -10814` because the binary has no LaunchServices registration. And do **not** run a bare `tccutil reset Calendar` (without a bundle ID): it wipes Calendar grants for *every* app on the machine and, on a pre-entitlements binary, leaves CheICalMCP permanently unable to re-prompt.
+
+### Claude Code updates rotate the host-side grant (#170)
+
+Under a Claude Code **native install**, the real executable lives at a **versioned path** (`~/.local/share/claude/versions/<version>`; `~/.local/bin/claude` is just a symlink), and macOS TCC keys the host-side Calendar/Reminders grant to that path. **Every Claude Code auto-update rotates the path and silently invalidates the grant** — the classic symptom is "worked yesterday, broken right after an update", with System Settings accumulating stale bare-version-number entries (`2.1.202`, `2.1.203`, …).
+
+**Fix**: trigger any calendar tool call from Claude Code so macOS re-prompts (or re-creates the entry), then toggle the **newest** version-number entry ON in System Settings → Privacy & Security → Calendars / Reminders. Full checklist: the `troubleshoot-tcc` skill (`/che-ical-mcp:check-tcc`). Root cause is upstream (tracked in [#170](https://github.com/PsychQuant/che-ical-mcp/issues/170) — Claude Code would need a stable TCC identity); this repo can only detect and document it.
 
 ### SSH Access
 


### PR DESCRIPTION
Refs #170

## Summary
README Troubleshooting 補上「Claude Code 更新輪替 versioned binary path → host 側 TCC grant 失效」的 symptom 表列 + 專節（現象、fix 步驟、troubleshoot-tcc skill pointer、upstream tracking 註記）— 補齊 verify 抓到的 gap：issue Expected 選項 1 寫「skill / README」，#171 只覆蓋了 skill 半邊（verify requirements MEDIUM-2，README 對 rotation 原為零覆蓋）。

## Verification
#170 verify（prose-adapted ensemble：2 lens + Codex gpt-5.5 + coordinator-DA fallback）PASS。詳見 issue #170 verify master report。本 PR 是該 verify 的 in-scope 修正之一。

## Checklist
- [x] Diagnose ✓（Simple / A_parallel_safe）
- [x] Implement（prose deliverables + 本 README commit 1914c72）
- [x] Verify ✓（見 issue #170 master report）
- [x] **Verify-gated**: ready to merge → after merge, run /idd-close to finalize（manual gate；no auto-close trailer）

---
🤖 Generated by /idd-all. **Do NOT add a GitHub close trailer**（Closes/Fixes/Resolves）— IDD discipline requires manual close via the skill after merge.
