### PR TITLE
chore: 版本位點對齊 1.14.2 — 修 VersionConsistency 紅燈 (#172)

### DIFF
--- a/Sources/CheICalMCP/Info.plist
+++ b/Sources/CheICalMCP/Info.plist
@@ -2,19 +2,19 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>CFBundleIdentifier</key>
-    <string>com.checheng.CheICalMCP</string>
-    <key>CFBundleName</key>
-    <string>CheICalMCP</string>
-    <key>CFBundleVersion</key>
-    <string>1.14.1</string>
-    <key>NSCalendarsFullAccessUsageDescription</key>
-    <string>CheICalMCP needs access to your calendars to manage events and schedules.</string>
-    <key>NSRemindersFullAccessUsageDescription</key>
-    <string>CheICalMCP needs access to your reminders to manage tasks.</string>
-    <key>NSCalendarsUsageDescription</key>
-    <string>CheICalMCP needs access to your calendars to manage events and schedules.</string>
-    <key>NSRemindersUsageDescription</key>
-    <string>CheICalMCP needs access to your reminders to manage tasks.</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.checheng.CheICalMCP</string>
+	<key>CFBundleName</key>
+	<string>CheICalMCP</string>
+	<key>CFBundleVersion</key>
+	<string>1.14.2</string>
+	<key>NSCalendarsFullAccessUsageDescription</key>
+	<string>CheICalMCP needs access to your calendars to manage events and schedules.</string>
+	<key>NSCalendarsUsageDescription</key>
+	<string>CheICalMCP needs access to your calendars to manage events and schedules.</string>
+	<key>NSRemindersFullAccessUsageDescription</key>
+	<string>CheICalMCP needs access to your reminders to manage tasks.</string>
+	<key>NSRemindersUsageDescription</key>
+	<string>CheICalMCP needs access to your reminders to manage tasks.</string>
 </dict>
 </plist>

--- a/Sources/CheICalMCP/Version.swift
+++ b/Sources/CheICalMCP/Version.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Centralized version management
 enum AppVersion {
     /// Current version - update this when releasing
-    static let current = "1.14.1"
+    static let current = "1.14.2"
 
     /// App name — the on-disk binary / product name, shown in `--version`,
     /// `--help` usage lines, and used as the argv0 fallback. Must match the

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "che-ical-mcp",
   "display_name": "macOS Calendar and Reminders",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "description": "Native EventKit integration for macOS Calendar and Reminders apps",
   "long_description": "A powerful MCP server providing 29 tools for managing macOS Calendar events and Reminders. Features include attendee/organizer read-only access, per-event timezone support, undo/redo, flexible date parsing, fuzzy calendar matching, batch operations with dry-run preview, advanced filtering/sorting/limiting, conflict detection, duplicate finding, multi-keyword search, recurring event occurrence-level operations, MCP-level #hashtag tags for reminders, and support for iCloud, Google, and Exchange calendars. Requires macOS 14.0 (Sonoma) or later.",
   "author": {


### PR DESCRIPTION
Refs #172

## Summary
`3b0df30` 只 bump 了 5 個版本位點中的 2 個，破壞 #163 single-version invariant，`VersionConsistencyTests` 紅燈至今且阻擋 PR #174/#176 CI。本 PR 把 `AppVersion.current`、`Info.plist` `CFBundleVersion`、`mcpb/manifest.json` 對齊 1.14.2。

## Verification
`swift test`：454 tests, **0 failures**（驗收即 issue Expected；`VersionConsistencyTests` 本身是 dedicated regression guard）。

## Checklist
- [x] Diagnose ✓（Simple；選項裁決：版本鎖步，v1.14.1 先例）
- [x] Implement（1 commit）
- [x] Verify ✓（機械驗收：dedicated test 0 failures）
- [x] **Verify-gated**: ready to merge → after merge, run /idd-close to finalize（no auto-close trailer）

---
🤖 Generated via IDD pipeline. **Do NOT add a GitHub close trailer**.